### PR TITLE
docs: fix local installation links

### DIFF
--- a/src/docs/data/docs/en/installation/index.mdx
+++ b/src/docs/data/docs/en/installation/index.mdx
@@ -11,10 +11,10 @@ This section describes how to setup your self-managed instance of Plumber.
 
 ## Installation methods
 
-- [⏱️ Trying Plumber on your local computer using Docker-compose](local-docker-compose)
+- [⏱️ Trying Plumber on your local computer using Docker-compose](docker-compose-local)
 - [🐳 Running Plumber using Docker-compose](docker-compose)
 - [🚀 Running Plumber on Kubernetes using a Helm chart](kubernetes)
-- [⏱️ Trying Plumber on your local computer using podman](local-podman) (supported by community)
+- [⏱️ Trying Plumber on your local computer using podman](podman-local) (supported by community)
 - [🕸 Running Plumber using podman](podman) (supported by community)
 
 ## Infrastructure


### PR DESCRIPTION
Links for local testing (docker compose, podman) are incorrect.