### PR TITLE
feat: Add 2 controls

### DIFF
--- a/src/data/blog/en/Hands-on CLI/index.mdx
+++ b/src/data/blog/en/Hands-on CLI/index.mdx
@@ -74,7 +74,7 @@ export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 plumber config generate
 ```
 
-This creates `.plumber.yaml`: your compliance contract defining 8 controls:
+This creates `.plumber.yaml`: your compliance contract defining 10 controls:
 
 1. Container images must not use forbidden tags
 2. Container images must come from authorized sources
@@ -84,6 +84,8 @@ This creates `.plumber.yaml`: your compliance contract defining 8 controls:
 6. Includes must not use forbidden versions
 7. Pipeline must include component
 8. Pipeline must include template
+9. Pipeline must not enable debug trace
+10. Pipeline must not use unsafe variable expansion
 
 ### Step 4: Run Your First Scan
 

--- a/src/docs/data/docs/en/cli/gitlab-component.mdx
+++ b/src/docs/data/docs/en/cli/gitlab-component.mdx
@@ -199,7 +199,7 @@ If you're running a self-hosted GitLab instance, you'll need to host your own co
 
 ## Compliance Controls
 
-Plumber includes **8 compliance controls**. Each can be enabled/disabled and customized in your `.plumber.yaml`:
+Plumber includes **10 compliance controls**. Each can be enabled/disabled and customized in your `.plumber.yaml`:
 
 | Control | Description |
 |---------|-------------|
@@ -211,6 +211,33 @@ Plumber includes **8 compliance controls**. Each can be enabled/disabled and cus
 | **Includes must not use forbidden versions** | Prevents mutable version references like `main`, `HEAD` |
 | **Pipeline must include component** | Ensures required CI/CD components are included; detects overridden jobs |
 | **Pipeline must include template** | Ensures required templates are included; detects overridden jobs |
+| **Pipeline must not enable debug trace** | Detects `CI_DEBUG_TRACE`/`CI_DEBUG_SERVICES` leaking secrets in job logs |
+| **Pipeline must not use unsafe variable expansion** | Detects user-controlled variables in shell re-interpretation contexts (OWASP CICD-SEC-1) |
+
+<details>
+<summary>**Unsafe Variable Expansion Detection**</summary>
+
+Detects user-controlled CI variables (MR title, commit message, branch name) passed to commands that re-interpret their input as shell code ([OWASP CICD-SEC-1](https://owasp.org/www-project-top-10-ci-cd-security-risks/)). Normal usage like `echo $CI_COMMIT_BRANCH` is safe; only re-interpretation contexts like `eval`, `sh -c`, and `bash -c` are flagged.
+
+Some legitimate usages (Helm deploys, Terraform, etc.) can be allowed via `allowedPatterns`:
+
+```yaml
+pipelineMustNotUseUnsafeVariableExpansion:
+  enabled: true
+  dangerousVariables:
+    - CI_MERGE_REQUEST_TITLE
+    - CI_COMMIT_MESSAGE
+    - CI_COMMIT_REF_NAME
+    - CI_COMMIT_BRANCH
+  allowedPatterns:
+    - "helm.*--set.*\\$CI_"
+    - "terraform workspace select.*\\$CI_"
+    - "docker build.*--build-arg.*\\$CI_"
+```
+
+See the [CLI documentation](/docs/cli/#available-controls) for the full list of flagged vs. safe patterns.
+
+</details>
 
 <Aside variant="tip">
   See the [full configuration reference](https://github.com/getplumber/plumber/blob/main/.plumber.yaml) for all control options.

--- a/src/docs/data/docs/en/cli/index.mdx
+++ b/src/docs/data/docs/en/cli/index.mdx
@@ -42,11 +42,11 @@ This is useful for local testing, CI/CD integration, or automated compliance che
     **Install a specific version:**
 
     ```bash
-    brew install getplumber/plumber/plumber@0.1.47
+    brew install getplumber/plumber/plumber@0.1.52
     ```
 
     <Aside variant="info">
-      Versioned formulas are keg-only. Use the full path (e.g., `/usr/local/opt/plumber@0.1.47/bin/plumber`) or run `brew link plumber@0.1.47` to add it to your PATH.
+      Versioned formulas are keg-only. Use the full path (e.g., `/usr/local/opt/plumber@0.1.52/bin/plumber`) or run `brew link plumber@0.1.52` to add it to your PATH.
     </Aside>
   </TabsContent>
 
@@ -412,7 +412,7 @@ Plumber uses a `.plumber.yaml` configuration file to customize checks.
 
 ### Available Controls
 
-Plumber includes **8 compliance controls**. Each can be enabled/disabled and customized:
+Plumber includes **10 compliance controls**. Each can be enabled/disabled and customized:
 
 | Control | Description |
 |---------|-------------|
@@ -424,6 +424,63 @@ Plumber includes **8 compliance controls**. Each can be enabled/disabled and cus
 | **Includes must not use forbidden versions** | Prevents mutable version references like `main`, `HEAD` |
 | **Pipeline must include component** | Ensures required CI/CD components are included; detects overridden jobs |
 | **Pipeline must include template** | Ensures required templates are included; detects overridden jobs |
+| **Pipeline must not enable debug trace** | Detects `CI_DEBUG_TRACE`/`CI_DEBUG_SERVICES` leaking secrets in job logs |
+| **Pipeline must not use unsafe variable expansion** | Detects user-controlled variables in shell re-interpretation contexts (OWASP CICD-SEC-1) |
+
+<details>
+<summary>**Unsafe Variable Expansion Detection**</summary>
+
+Detects user-controlled CI variables (MR title, commit message, branch name) passed to commands that re-interpret their input as shell code. This is [OWASP CICD-SEC-1](https://owasp.org/www-project-top-10-ci-cd-security-risks/).
+
+GitLab sets CI variables as environment variables. The shell does **not** re-parse expanded values for command substitution, so normal usage is safe. Only commands that re-interpret their arguments as code are flagged:
+
+**Flagged** (re-interpretation contexts):
+
+```bash
+eval "$CI_COMMIT_BRANCH"
+sh -c "$CI_MERGE_REQUEST_TITLE"
+bash -c "$CI_COMMIT_MESSAGE"
+source <(echo "$CI_COMMIT_REF_NAME")
+echo "$CI_COMMIT_BRANCH" | xargs sh
+```
+
+**Not flagged** (safe, the shell doesn't re-parse env var values):
+
+```bash
+echo $CI_COMMIT_BRANCH
+curl -d "$CI_MERGE_REQUEST_TITLE" https://...
+git checkout $CI_COMMIT_REF_NAME
+printf '%s' "$CI_COMMIT_MESSAGE"
+```
+
+**Allowing specific patterns**
+
+Some `sh -c` or `bash -c` usages are legitimate (e.g., Helm deploys, Terraform workspaces). Use `allowedPatterns` (regex) to suppress those findings. Each pattern is matched against the full script line.
+
+```yaml
+pipelineMustNotUseUnsafeVariableExpansion:
+  enabled: true
+  dangerousVariables:
+    - CI_MERGE_REQUEST_TITLE
+    - CI_COMMIT_MESSAGE
+    - CI_COMMIT_REF_NAME
+    - CI_COMMIT_REF_SLUG
+    - CI_COMMIT_BRANCH
+  allowedPatterns:
+    - "helm.*--set.*\\$CI_"
+    - "terraform workspace select.*\\$CI_"
+    - "docker build.*--build-arg.*\\$CI_"
+    - "aws s3 sync.*\\$CI_"
+    - "make deploy.*\\$CI_"
+```
+
+For example, the script line `sh -c "helm upgrade myapp . --set image.tag=$CI_COMMIT_SHA"` would normally be flagged, but the pattern `helm.*--set.*\\$CI_` allows it.
+
+<Aside variant="info">
+  Escape `$` as `\\$` and `{`/`}` as `\\{`/`\\}` in patterns. Only direct variable names are detected. Indirect aliasing (`variables: { B: $CI_COMMIT_BRANCH }` then `sh -c $B`) is not tracked.
+</Aside>
+
+</details>
 
 ### Example Configuration
 
@@ -495,6 +552,34 @@ controls:
     # requiredGroups:
     #   - ["templates/go/go", "templates/trivy/trivy"]
     #   - ["templates/full-go-pipeline"]
+
+  # Detect debug trace variables that leak secrets in job logs
+  pipelineMustNotEnableDebugTrace:
+    enabled: true
+    forbiddenVariables:
+      - CI_DEBUG_TRACE
+      - CI_DEBUG_SERVICES
+
+  # Detect user-controlled variables in shell re-interpretation contexts (eval, sh -c, etc.)
+  # Safe: echo $CI_COMMIT_BRANCH. Dangerous: eval "deploy $CI_COMMIT_BRANCH"
+  pipelineMustNotUseUnsafeVariableExpansion:
+    enabled: true
+    dangerousVariables:
+      - CI_MERGE_REQUEST_TITLE
+      - CI_MERGE_REQUEST_DESCRIPTION
+      - CI_COMMIT_MESSAGE
+      - CI_COMMIT_TITLE
+      - CI_COMMIT_TAG_MESSAGE
+      - CI_COMMIT_REF_NAME
+      - CI_COMMIT_REF_SLUG
+      - CI_COMMIT_BRANCH
+      - CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+      - CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
+    # Regex patterns to allow specific script lines (escape $ as \\$)
+    allowedPatterns:
+      - "helm.*--set.*\\$CI_"
+      - "terraform workspace select.*\\$CI_"
+      - "docker build.*--build-arg.*\\$CI_"
 ```
 
 <Aside variant="info">
@@ -535,7 +620,9 @@ Controls not selected are reported as **skipped** in the output. The `--controls
 | `includesMustNotUseForbiddenVersions` |
 | `pipelineMustIncludeComponent` |
 | `pipelineMustIncludeTemplate` |
+| `pipelineMustNotEnableDebugTrace` |
 | `pipelineMustNotIncludeHardcodedJobs` |
+| `pipelineMustNotUseUnsafeVariableExpansion` |
 
 </details>
 


### PR DESCRIPTION
- pipelineMustNotUseUnsafeVariableExpansion which detects variables that can be used in scripts
- pipelineMustNotEnableDebugTrace which detects pipelines that have debug enabled, printing all envs

closes #78 