### PR TITLE
fix: harden GitHub Actions workflows against supply chain attacks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,16 +6,21 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy-preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,12 +1,17 @@
 name: Deploy Production
 
 on:
+  # zizmor: ignore[dangerous-triggers] — workflow_run is used safely here:
+  # only triggers after Lint succeeds on main, checkouts a specific SHA
   workflow_run:
     workflows: ["Lint"]
     types: [completed]
     branches:
       - main
       - master
+
+permissions:
+  contents: read
 
 jobs:
   deploy-production:
@@ -15,12 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/seo-audit.yml
+++ b/.github/workflows/seo-audit.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"
@@ -45,14 +45,15 @@ jobs:
 
       - name: Run SEO Audit
         id: seo-audit
+        env:
+          SITE_URL: ${{ github.event.inputs.site_url || 'https://getplumber.io' }}
+          OUTPUT_FORMAT: ${{ github.event.inputs.output_format || 'json' }}
         run: |
-          SITE_URL="${{ github.event.inputs.site_url || 'https://getplumber.io' }}"
-          OUTPUT_FORMAT="${{ github.event.inputs.output_format || 'json' }}"
           node scripts/seo-audit.js --url "$SITE_URL" --output "$OUTPUT_FORMAT" > seo-report.json || true
         continue-on-error: true
 
       - name: Upload SEO Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: seo-report
           path: seo-report.json
@@ -60,7 +61,7 @@ jobs:
 
       - name: Parse and Comment Results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');
@@ -103,7 +104,7 @@ jobs:
 
       - name: Create Issue on Score Drop
         if: github.event_name == 'schedule' && failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

Harden all 5 GitHub Actions workflows against the anti-patterns exploited in the [hackerbot-claw campaign](https://blog.stephane-robert.info/post/trivy-depot-github-vide/) (aquasecurity/trivy, CVE-2025-30066).

## Changes

### All workflows (5/5)
- **Pin all actions by SHA commit** instead of mutable tags — prevents tag hijacking (the exact vector used in tj-actions/changed-files CVE-2025-30066)
  - `actions/checkout` → `v6.0.2` (`de0fac2e...`)
  - `actions/setup-node` → `v6.2.0` (`6044e13b...`)
  - `actions/upload-artifact` → `v7.0.0` (`bbbca2dd...`)
  - `actions/github-script` → `v7.1.0` (`f28e40c7...`)

### preview.yaml
- Add `permissions: contents: read` (was missing → default write permissions)
- Add `persist-credentials: false` on checkout

### production.yaml
- Add `permissions: contents: read` (was missing → default write permissions)
- Add `persist-credentials: false` on checkout
- Annotate `workflow_run` trigger (intentional, safe usage — checkouts a specific SHA)

### seo-audit.yml
- **Fix command injection**: move `${{ github.event.inputs.* }}` from `run:` blocks to `env:` variables — prevents shell injection via `workflow_dispatch` inputs

### lint.yml, security.yml
- Actions pinned by SHA (already had `persist-credentials: false` and explicit permissions)

## Validation

Audited with [zizmor](https://github.com/zizmorcore/zizmor) v1.22.0: **0 findings** (1 intentionally ignored, 17 suppressed = fixed).

## Anti-patterns addressed

| Anti-pattern (hackerbot-claw) | Status |
|---|---|
| Actions referenced by mutable tag | ✅ Fixed — all pinned by SHA |
| Missing `permissions:` declaration | ✅ Fixed — preview.yaml, production.yaml |
| `persist-credentials` not disabled | ✅ Fixed — preview.yaml, production.yaml |
| `${{ }}` interpolation in `run:` blocks | ✅ Fixed — seo-audit.yml |
| `pull_request_target` | ✅ Not used (never was) |