### PR TITLE
chore(docs): replace code blocks with ExpressiveCode component for be…

### DIFF
--- a/src/pages/docs/use-plumber/issues/[code].astro
+++ b/src/pages/docs/use-plumber/issues/[code].astro
@@ -14,6 +14,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/starwind/breadcrumb";
+import { Code as ExpressiveCode } from "astro-expressive-code/components";
 import { Icon } from "astro-icon/components";
 import DocsLayoutStandalone from "@/docs/layouts/DocsLayoutStandalone.astro";
 import { issues, type IssueDoc } from "@/data/issues";
@@ -265,9 +266,11 @@ const pageHeadings: { depth: number; slug: string; text: string }[] = [
         >
         <span class="text-sm text-muted-foreground">{badExampleCaption}</span>
       </div>
-      <pre
-        class="overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm leading-relaxed ring-1 ring-red-900/30"
-        ><code class="text-zinc-300">{badExample}</code></pre>
+      <ExpressiveCode
+        code={badExample}
+        lang="yaml"
+        class="overflow-x-auto rounded-lg text-sm leading-relaxed"
+      />
     </div>
 
     <!-- Good example -->
@@ -279,9 +282,11 @@ const pageHeadings: { depth: number; slug: string; text: string }[] = [
         >
         <span class="text-sm text-muted-foreground">{goodExampleCaption}</span>
       </div>
-      <pre
-        class="overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm leading-relaxed ring-1 ring-emerald-900/30"
-        ><code class="text-zinc-300">{goodExample}</code></pre>
+      <ExpressiveCode
+        code={goodExample}
+        lang="yaml"
+        class="overflow-x-auto rounded-lg text-sm leading-relaxed"
+      />
     </div>
   </section>
 


### PR DESCRIPTION
…tter syntax highlighting

- Updated bad and good example sections to use the ExpressiveCode component for YAML code snippets, enhancing readability and presentation.