### PR TITLE
docs: Mark ISSUE-411 GitHub control as shipping and align CLI examples.

### DIFF
--- a/src/data/issues.ts
+++ b/src/data/issues.ts
@@ -1935,7 +1935,6 @@ jobs:
         "Pipe-to-shell substrings inside a quoted string (`echo \"Install with curl … | bash\"`) are documentation, not execution — they do not fire.",
         "Heredoc-to-shell with no download on the line (`cat <<EOF | bash`) is operator-authored, in-tree content. Any unsafe download inside the heredoc body still fires on its own script line.",
         "Inline payloads on `pull_request_target` workflows are especially dangerous — combine ISSUE-411 with ISSUE-802 (dangerous-triggers) for the full Megalodon defence.",
-        "GitHub Actions support for this control is tracked in getplumber/plumber issue #201.",
       ],
       relatedCodes: ["ISSUE-207", "ISSUE-802", "ISSUE-703"],
     },

--- a/src/docs/data/docs/en/cli/github/index.mdx
+++ b/src/docs/data/docs/en/cli/github/index.mdx
@@ -378,7 +378,7 @@ github:
 <details>
 <summary>**Unverified Script Execution Detection (GitHub)**</summary>
 
-Detects workflow `run:` steps that download and immediately execute scripts from the internet without integrity verification. This is the GitHub Actions counterpart of the GitLab control and targets the Megalodon attack pattern: obfuscated base64 payloads piped to a shell (`echo "…" | base64 -d | bash`) as well as classic `curl | bash` / `wget | sh` chains. Maps to [OWASP CICD-SEC-3](https://owasp.org/www-project-top-10-ci-cd-security-risks/) (Dependency Chain Abuse) and CICD-SEC-8 (Ungoverned Usage of 3rd Party Services). Tracked in [getplumber/plumber#201](https://github.com/getplumber/plumber/issues/201).
+Detects workflow `run:` steps that download and immediately execute scripts from the internet without integrity verification. This is the GitHub Actions counterpart of the GitLab control and targets the Megalodon attack pattern: obfuscated base64 payloads piped to a shell (`echo "…" | base64 -d | bash`) as well as classic `curl | bash` / `wget | sh` chains. Maps to [OWASP CICD-SEC-3](https://owasp.org/www-project-top-10-ci-cd-security-risks/) (Dependency Chain Abuse) and CICD-SEC-8 (Ungoverned Usage of 3rd Party Services).
 
 **Detected patterns:**
 - Direct pipe to shell: `curl ... | bash`, `wget ... | sh`, `curl ... | python`, and any `<command> | <shell>` chain
@@ -389,10 +389,12 @@ Detects workflow `run:` steps that download and immediately execute scripts from
 Lines that include checksum or signature verification (`sha256sum`, `gpg --verify`, `cosign verify`, and similar) on the same line as the download are excluded.
 
 ```yaml
-pipelineMustNotExecuteUnverifiedScripts:
-  enabled: true
-  trustedUrls: []
-    # - https://internal-artifacts.example.com/*
+github:
+  controls:
+    pipelineMustNotExecuteUnverifiedScripts:
+      enabled: true
+      trustedUrls: []
+        # - https://internal-artifacts.example.com/*
 ```
 
 Add trusted URL patterns to `trustedUrls` (host-precise globs) to suppress findings for known-good sources.


### PR DESCRIPTION
Remove stale plumber#201 tracking references now that the control ships on GitHub Actions, and wrap the unverified-scripts YAML snippet under github.controls like the other default-on control sections.