### PR TITLE
fix(docs): enable GFM so markdown tables render in MDX

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,6 +36,8 @@ export default defineConfig({
     },
   },
   markdown: {
+    // Required for GFM tables when a custom markdown block is set (otherwise gfm defaults to off in MDX).
+    gfm: true,
     shikiConfig: {
       // Shiki Themes: https://shiki.style/themes
       theme: "css-variables",


### PR DESCRIPTION
A custom markdown config overrides Astro defaults and left gfm unset, so pipe tables on CLI and other docs pages rendered as plain text.