### PR TITLE
docs: add ISSUE-713 (githubActionMustComeFromAuthorizedSources)

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -28,6 +28,6 @@ jobs:
           sudo install gitleaks /usr/local/bin/gitleaks
           rm gitleaks gitleaks.tar.gz
 
-      - uses: getplumber/plumber@e2ab0a859edf8ac868ffc726916ea5053c1bf356   # v0.3.56
+      - uses: getplumber/plumber@ee262c066548fdcf878b593020d78411582e987c   # v0.3.61
         with:
           threshold: 90

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -28,6 +28,6 @@ jobs:
           sudo install gitleaks /usr/local/bin/gitleaks
           rm gitleaks gitleaks.tar.gz
 
-      - uses: getplumber/plumber@ee262c066548fdcf878b593020d78411582e987c   # v0.3.61
+      - uses: getplumber/plumber@c2651456dd3775c552f6fa626ca6130ffd913579   # v0.3.62
         with:
           threshold: 90

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,7 +40,10 @@ export default defineConfig({
     },
   },
   markdown: {
-    // Required for GFM tables when a custom markdown block is set (otherwise gfm defaults to off in MDX).
+    // gfm defaults to true, but astro 6.4.x stopped applying it through the
+    // (now-deprecated) markdown remark-plugin path that an integration wires
+    // up, which silently dropped GFM tables site-wide. Setting it explicitly
+    // restores table rendering.
     gfm: true,
     shikiConfig: {
       // Shiki Themes: https://shiki.style/themes

--- a/src/data/issues.ts
+++ b/src/data/issues.ts
@@ -34,6 +34,13 @@ export interface IssueProviderContent {
   controlName: string;
   controlConfigKey: string;
   description: string;
+  /**
+   * Optional bullet points rendered as a list directly under the
+   * description in the "What is this?" section. Each entry supports
+   * inline `code`. Use for enumerations that read better as a list than
+   * as inline "(a) … (b) …" prose.
+   */
+  descriptionPoints?: string[];
   impact: string;
   remediation: string;
   /** YAML/config example showing the problematic configuration */
@@ -361,6 +368,14 @@ export const controlCatalog: Record<
         "Step-level `uses: owner/repo@ref` in committed workflows. Queries GitHub for `archived: true` (one cached API call per `owner/repo`). Requires `gh` / `GH_TOKEN`; abstains without auth.",
       controlWhyItMatters:
         "Archived repos stop receiving patches. Does not inspect reusable-workflow callees, local actions, or runtime installs. PBOM: `archived: true`.",
+    },
+  },
+  githubActionMustComeFromAuthorizedSources: {
+    github: {
+      controlDescription:
+        "Restricts every step-level `uses:` and job-level reusable-workflow `uses:` to authorized sources: GitHub-official owners (`actions/*`, `github/*`), the scanned repo's own org (`trustSameOrgActions`, default on), a `trustedGithubActions` allowlist (exact `owner/repo` or `owner/*` wildcard), or a `minimumStars` popularity floor.",
+      controlWhyItMatters:
+        "Third-party actions run with the caller's `GITHUB_TOKEN` and secrets, so an unvetted owner is a direct supply-chain entry point. The star floor also catches rename/re-creation namespace squats. Local `./…` and `docker://` refs are exempt; `minimumStars` needs API auth and falls back to the allowlist without it.",
     },
   },
   actionsMustNotCarryKnownCVEs: {
@@ -2961,6 +2976,76 @@ jobs:
       ],
       status: "roadmap",
       relatedCodes: ["ISSUE-701"],
+    },
+  },
+
+  "ISSUE-713": {
+    code: "ISSUE-713",
+    github: {
+      title: "Action comes from an unauthorized source",
+      category: "Third-party actions",
+      severity: "high",
+      fixDuration: "medium",
+      productScope: "cli",
+      controlName: "Actions must come from authorized sources",
+      controlConfigKey: "githubActionMustComeFromAuthorizedSources",
+      description:
+        "A workflow references a GitHub Action whose source is not authorized. The control checks every step-level `uses: owner/repo@ref` and every job-level reusable-workflow `uses:`, and flags any reference that is not trusted by one of:",
+      descriptionPoints: [
+        "a GitHub-official owner (`actions/*`, `github/*`, trusted by default)",
+        "the same org/user as the scanned repository (`trustSameOrgActions`, trusted by default)",
+        "the `trustedGithubActions` allowlist (exact `owner/repo` or `owner/*` wildcard)",
+        "a `minimumStars` floor — when set, the action's upstream repository has at least that many stars",
+      ],
+      impact:
+        "Every third-party action runs inside the caller workflow with its `GITHUB_TOKEN` and secrets, so an unvetted owner is a direct supply-chain entry point — the vector behind the `tj-actions/changed-files` compromise (CVE-2025-30066). The `minimumStars` floor additionally catches the rename/re-creation squat, where an attacker re-registers a once-trusted repository name with no history.",
+      remediation:
+        "Use an action from an authorized source. Keep `trustGithubOfficialActions` on for `actions/*` and `github/*`, add trusted owners or actions to `trustedGithubActions` (exact `owner/repo` or `owner/*`), and optionally set `minimumStars` to require a popularity threshold. Vendoring the action into a local `./.github/actions/…` directory removes the external dependency entirely.",
+      badExample: `# .github/workflows/ci.yml — ❌ Actions from unvetted owners
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4              # official — trusted
+      - uses: random-dev/handy-action@v1       # unknown owner — flagged
+      - uses: tj-actions/changed-files@v45     # not on the allowlist — flagged
+  deploy:
+    # Job-level reusable workflow from an unauthorized owner — flagged.
+    uses: acme/shared-workflows/.github/workflows/deploy.yml@main`,
+      badExampleCaption:
+        "Only `actions/checkout` is trusted; the two third-party steps and the reusable-workflow call all come from unauthorized owners.",
+      goodExample: `# .github/workflows/ci.yml — ✅ Only authorized sources
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4              # official
+      - uses: mycompany/handy-action@v1        # allowed via mycompany/*
+      - uses: jdx/mise-action@v2               # allowed by exact entry
+
+# .plumber.yaml — opt in and define the trusted set
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      enabled: true
+      trustGithubOfficialActions: true   # trust actions/* and github/*
+      trustSameOrgActions: true          # trust your org's own actions
+      minimumStars: 0                    # > 0 to require a popularity floor (API)
+      trustedGithubActions:
+        - mycompany/*                    # whole-org wildcard
+        - jdx/mise-action               # exact owner/repo`,
+      goodExampleCaption:
+        "Every `uses:` resolves to an official owner, your own org, an allowlist match, or (when enabled) a starred repo.",
+      tips: [
+        "Trust is satisfied by ANY of: a GitHub-official owner (`actions/*`, `github/*`, on by default), the scanned repo's own org (`trustSameOrgActions`, on by default), a `trustedGithubActions` match, or — when `minimumStars > 0` — enough stars on the action repo.",
+        "`trustSameOrgActions` trusts actions whose owner matches the scanned repository's owner (case-insensitive). It abstains when the repo owner is unknown (e.g. no GitHub remote), so it never grants trust on missing data.",
+        "`trustedGithubActions` accepts an exact `owner/repo` (`jdx/mise-action`) or an `owner/*` whole-org wildcard (`mycompany/*`). Bare owners and arbitrary globs are not supported.",
+        "Job-level reusable-workflow calls (`jobs.<id>.uses`) are checked too, but only against the official-owner and allowlist rules — they carry no star metadata.",
+        "`minimumStars` reads star counts from the GitHub API and needs `gh` / `GH_TOKEN`. Without it, a reference falls back to the allowlist rather than being flagged on missing data.",
+        "Local actions (`uses: ./.github/actions/foo`) and `docker://` image steps are always exempt.",
+      ],
+      status: "shipping",
+      relatedCodes: ["ISSUE-701", "ISSUE-702", "ISSUE-703"],
     },
   },
 

--- a/src/docs/data/docs/en/cli/github/index.mdx
+++ b/src/docs/data/docs/en/cli/github/index.mdx
@@ -206,7 +206,7 @@ The CLI output is color-coded in your terminal for easy scanning: green for pass
 
 ## Available Controls
 
-Plumber ships **16 GitHub controls** (14 default-on plus the opt-in `workflowMustIncludeRequiredActions` and `pipelineMustNotLeakSecretsInConfig`). Each can be enabled / disabled and customized in `.plumber.yaml`. When a control detects a violation, it creates an **Issue** (e.g., `ISSUE-701`) with a direct link to its documentation page.
+Plumber ships **17 GitHub controls** (15 default-on plus the opt-in `workflowMustIncludeRequiredActions` and `pipelineMustNotLeakSecretsInConfig`). Each can be enabled / disabled and customized in `.plumber.yaml`. When a control detects a violation, it creates an **Issue** (e.g., `ISSUE-701`) with a direct link to its documentation page.
 
 | Control | Issues | Description |
 |---------|--------|-------------|
@@ -223,6 +223,7 @@ Plumber ships **16 GitHub controls** (14 default-on plus the opt-in `workflowMus
 | **Third-party actions must be pinned by commit SHA** | [ISSUE-701](/docs/cli/issues/ISSUE-701) | Requires `uses: owner/repo@<sha>` (40-char commit SHA) instead of a mutable tag or branch ref. `trustedOwners` exempts first-party `actions/*` and `github/*` |
 | **Actions must not reference archived repositories** | [ISSUE-702](/docs/cli/issues/ISSUE-702) | Flags `uses:` refs whose upstream GitHub repository has been archived (no security patches coming). One cached API call per unique ref |
 | **Actions must not carry known CVEs** | [ISSUE-703](/docs/cli/issues/ISSUE-703) | Cross-references every pinned action against the GitHub Advisory Database (`actions` ecosystem), semver-filtered so refs past the fix stay silent |
+| **Actions must come from authorized sources** | [ISSUE-713](/docs/cli/issues/ISSUE-713) | Restricts step and reusable-workflow `uses:` to GitHub-official owners (`actions/*`, `github/*`), the scanned repo's own org, a `trustedGithubActions` allowlist (exact or `owner/*`), or a `minimumStars` floor |
 | **Workflow permissions must be declared** | [ISSUE-801](/docs/cli/issues/ISSUE-801) | Flags workflows missing an explicit `permissions:` block (falls back to the repo-wide `GITHUB_TOKEN` default) |
 | **Workflow must not use dangerous triggers** | [ISSUE-802](/docs/cli/issues/ISSUE-802) | Flags `pull_request_target` and `workflow_run`, which run with base-repo secrets while being influenceable by an unprivileged caller |
 | **Job must not run with write-all permissions** | [ISSUE-803](/docs/cli/issues/ISSUE-803) | Flags `permissions: write-all` at workflow or job scope. Pairs with `workflowsMustDeclarePermissions` to close the least-privilege loop |
@@ -353,6 +354,7 @@ plumber explain 703
 | [ISSUE-701](/docs/cli/issues/ISSUE-701?p=github) | Third-party action not pinned by commit SHA |
 | [ISSUE-702](/docs/cli/issues/ISSUE-702?p=github) | Action hosted in an archived repository |
 | [ISSUE-703](/docs/cli/issues/ISSUE-703?p=github) | Action carries a known security advisory (CVE) |
+| [ISSUE-713](/docs/cli/issues/ISSUE-713?p=github) | Action comes from an unauthorized source |
 | [ISSUE-801](/docs/cli/issues/ISSUE-801?p=github) | Workflow permissions not declared |
 | [ISSUE-802](/docs/cli/issues/ISSUE-802?p=github) | Workflow uses a dangerous trigger |
 | [ISSUE-803](/docs/cli/issues/ISSUE-803?p=github) | Workflow grants `write-all` permissions |
@@ -385,6 +387,19 @@ github:
     # Database under the `actions` ecosystem.
     actionsMustNotCarryKnownCVEs:
       enabled: true
+
+    # Restrict step and reusable-workflow `uses:` to authorized sources.
+    # Trust = official owners (actions/*, github/*), your own org
+    # (trustSameOrgActions), the allowlist below (exact owner/repo or
+    # owner/* wildcard), or a minimum-stars floor.
+    githubActionMustComeFromAuthorizedSources:
+      enabled: true
+      trustGithubOfficialActions: true
+      trustSameOrgActions: true
+      minimumStars: 0
+      trustedGithubActions:
+        - jdx/mise-action
+        # - mycompany/*
 
     # Same forbidden-tag list as GitLab plus a digest-pinning sub-option.
     containerImageMustNotUseForbiddenTags:
@@ -516,6 +531,7 @@ Controls not selected are reported as **skipped** in the output. The `--controls
 | `actionsMustBePinnedByCommitSha` |
 | `actionsMustNotBeArchived` |
 | `actionsMustNotCarryKnownCVEs` |
+| `githubActionMustComeFromAuthorizedSources` |
 | `branchMustBeProtected` |
 | `containerImageMustNotUseForbiddenTags` |
 | `pipelineMustNotEnableDebugTrace` |

--- a/src/pages/docs/[section]/issues/[code].astro
+++ b/src/pages/docs/[section]/issues/[code].astro
@@ -361,6 +361,15 @@ function configKeyExample(provider: Provider, configKey: string): string {
               <span>📋</span> What is this?
             </h2>
             <p class="text-foreground/80 leading-relaxed" set:html={inlineCodeToHtml(c.description)} />
+            {
+              c.descriptionPoints && c.descriptionPoints.length > 0 && (
+                <ul class="mt-3 list-disc space-y-1 pl-6 text-foreground/80 leading-relaxed">
+                  {c.descriptionPoints.map((point) => (
+                    <li set:html={inlineCodeToHtml(point)} />
+                  ))}
+                </ul>
+              )
+            }
           </section>
 
           <section id={`impact-${p.id}`} class="mb-8 scroll-mt-[calc(var(--nav-height)+1rem)]">


### PR DESCRIPTION
Documents the new GitHub-only supply-chain control **ISSUE-713 / `githubActionMustComeFromAuthorizedSources`**, shipping in the plumber CLI (closes getplumber/plumber#253).

## What's added

**`src/data/issues.ts`** (the structured source the issue pages + Controls table render from):
- `issues["ISSUE-713"]` — full GitHub detail entry (title, severity `high`, description, impact, remediation, bad/good examples, 5 tips, `relatedCodes`, `status: "shipping"`). The detail page at `/docs/cli/issues/ISSUE-713` auto-generates from this via `getStaticPaths`.
- `controlCatalog.githubActionMustComeFromAuthorizedSources` — the "What it checks / Why it matters" copy that `ControlsTable` pulls in (so the control renders correctly on `/docs/use-plumber/controls`).

**`src/docs/data/docs/en/cli/github/index.mdx`** (hand-maintained GitHub reference) — added ISSUE-713 to all four spots its sibling action controls (701/702/703) appear:
1. Control | Issues | Description table
2. Issue | Description quick-reference table
3. Example `.plumber.yaml` config block
4. "Valid GitHub control names" list

## Completeness check

Verified against the sibling action controls that nothing else needs touching: `issueCodeRedirects.ts` is legacy-rename-only (N/A for a new code), `issueCategoryOrder.ts` ranks by numeric code + the existing "Third-party actions" category (auto), and `controls.mdx` uses the auto-generated `<ControlsTable>`.

`npx astro check` → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)