### PR TITLE
feat(seo): add TechArticle + BreadcrumbList JSON-LD to docs pages

### DIFF
--- a/src/docs/components/seo/Seo.astro
+++ b/src/docs/components/seo/Seo.astro
@@ -6,7 +6,7 @@ import { SEO } from "astro-seo";
 import { getCanonicalDocsPathname } from "@/docs/js/docsUtils";
 import { getLocaleFromUrl } from "@/docs/js/localeUtils";
 import { getTranslatedData } from "@/docs/js/translationUtils";
-import jsonLDGenerator from "@/js/jsonLD";
+import jsonLDGenerator, { type BreadcrumbItem } from "@/js/jsonLD";
 
 import HrefLang from "./HrefLang.astro";
 
@@ -18,15 +18,23 @@ interface Props {
   description: string;
   image?: ImageMetadata;
   noindex?: boolean;
+  /**
+   * Per-page docs structured data. When provided, emits a TechArticle +
+   * BreadcrumbList graph instead of the generic Organization/WebSite one.
+   * `headline` should be the visible H1 (not the suffixed meta title).
+   */
+  structuredData?: {
+    headline?: string;
+    breadcrumbs?: BreadcrumbItem[];
+  };
 }
 
-const { title: rawTitle, description, image, noindex = false } = Astro.props;
+const { title: rawTitle, description, image, noindex = false, structuredData } = Astro.props;
 
 // Append brand suffix unless the title already contains "Plumber"
 const title = rawTitle.includes("Plumber") ? rawTitle : `${rawTitle} | Plumber Docs`;
 
 let optimizedImage;
-const jsonLD = jsonLDGenerator({ type: "general" });
 
 // Normalize canonical URL: remove trailing slash except for root
 function normalizeCanonicalPath(pathname: string): string {
@@ -39,6 +47,16 @@ function normalizeCanonicalPath(pathname: string): string {
 // Shared Platform/CLI content canonicalizes to its CLI URL (the sitemap variant)
 const normalizedPathname = getCanonicalDocsPathname(normalizeCanonicalPath(Astro.url.pathname));
 const canonicalUrl = new URL(normalizedPathname, Astro.site);
+
+const jsonLD = structuredData?.breadcrumbs
+  ? jsonLDGenerator({
+      type: "docs",
+      headline: structuredData.headline ?? rawTitle,
+      description,
+      canonicalUrl,
+      breadcrumbs: structuredData.breadcrumbs,
+    })
+  : jsonLDGenerator({ type: "general" });
 
 if (image) {
   optimizedImage = await getImage({
@@ -99,5 +117,5 @@ const imageUrl =
 <!-- hreflang attributes -->
 <HrefLang />
 
-<!-- JSON-LD (Organization + WebSite for SEO/AEO) -->
+<!-- JSON-LD: per-page TechArticle + BreadcrumbList when available, else Organization + WebSite -->
 <Fragment set:html={jsonLD} />

--- a/src/docs/js/docsUtils.ts
+++ b/src/docs/js/docsUtils.ts
@@ -1,7 +1,8 @@
-import { getCollection } from "astro:content";
+import { type CollectionEntry, getCollection } from "astro:content";
 
 import { defaultLocale, locales, siteSettings } from "@/docs/config/siteSettings.json";
 import type { DocsSection, DocsSidebarNavData, DocsTab } from "@/docs/config/types/configDataTypes";
+import type { BreadcrumbItem } from "@/js/jsonLD";
 
 import { filterCollectionByLanguage } from "./localeUtils";
 import { getTranslatedData } from "./translationUtils";
@@ -171,6 +172,59 @@ export const getSectionTitle = (sectionId: string, tabId: string, locale: Locale
     .split("-")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
+};
+
+/**
+ * Build BreadcrumbList items (Home → Section → Page) for a docs content page.
+ *
+ * Validity first: the section crumb is only added when that section actually
+ * has a landing page, so the emitted `item` URL never points at a 404 (a
+ * broken breadcrumb link is exactly what gets pages dropped from rich results).
+ * URLs follow the canonical path, so use-plumber shared content links under
+ * /docs/cli to match the canonical tag. The final crumb (current page) omits
+ * `item`, which schema.org allows.
+ */
+export const getDocsBreadcrumbs = async (
+  doc: CollectionEntry<"docs">,
+  tabId: string,
+  locale: LocaleType,
+  siteUrl: string,
+): Promise<BreadcrumbItem[]> => {
+  const base = siteUrl.replace(/\/$/, "");
+  const crumbs: BreadcrumbItem[] = [{ name: "Home", item: `${base}/` }];
+
+  const pagePath = getCanonicalDocsPathname(`/${docsRoute}/${contentIdToTabSlug(doc.id, tabId)}`);
+  // e.g. ["docs", "installation", "kubernetes"]
+  const segments = pagePath.split("/").filter(Boolean);
+
+  // Only intermediate (sub-)pages get a section crumb, and only when that
+  // section has its own landing page to link to.
+  if (segments.length > 2) {
+    const sectionSegment = segments[1];
+    const allDocs = await getCollection("docs");
+    // The glob loader collapses `<section>/index.mdx` into the id `<section>`,
+    // so the section landing's id is the segment itself. Match with and without
+    // the locale prefix (filterCollectionByLanguage strips it in place, so its
+    // presence at call time isn't guaranteed).
+    const landingIds = new Set([
+      sectionSegment,
+      ...locales.map((loc) => `${loc}/${sectionSegment}`),
+    ]);
+    const landing = allDocs.find(
+      (entry) => landingIds.has(entry.id) && entry.data.draft !== true,
+    );
+    if (landing) {
+      // Use the landing page's own title so the crumb name matches the H1 of
+      // the page it links to (sidebar labels are tuned for the nav, not SERPs).
+      crumbs.push({
+        name: landing.data.title,
+        item: `${base}/${docsRoute}/${sectionSegment}`,
+      });
+    }
+  }
+
+  crumbs.push({ name: doc.data.title });
+  return crumbs;
 };
 
 /**

--- a/src/docs/layouts/BaseHead.astro
+++ b/src/docs/layouts/BaseHead.astro
@@ -4,15 +4,20 @@ import { ClientRouter } from "astro:transitions";
 
 import Seo from "@/docs/components/seo/Seo.astro";
 import siteSettings from "@/docs/config/siteSettings.json";
+import type { BreadcrumbItem } from "@/js/jsonLD";
 
 export interface Props {
   title: string;
   description: string;
   image?: ImageMetadata;
   noindex?: boolean;
+  structuredData?: {
+    headline?: string;
+    breadcrumbs?: BreadcrumbItem[];
+  };
 }
 
-const { title, description, image, noindex = false } = Astro.props as Props;
+const { title, description, image, noindex = false, structuredData } = Astro.props as Props;
 
 import InterVariable from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2";
 ---
@@ -69,7 +74,13 @@ import InterVariable from "@fontsource-variable/inter/files/inter-latin-wght-nor
   document.addEventListener("astro:after-swap", initTheme);
 </script>
 
-<Seo title={title} description={description} image={image} noindex={noindex} />
+<Seo
+  title={title}
+  description={description}
+  image={image}
+  noindex={noindex}
+  structuredData={structuredData}
+/>
 
 <!-- Plausible Analytics (cookieless; proxy per https://plausible.io/docs/proxy/guides/vercel) -->
 <script async src="/js/script.js"></script>

--- a/src/docs/layouts/BaseLayoutDocs.astro
+++ b/src/docs/layouts/BaseLayoutDocs.astro
@@ -10,6 +10,7 @@ import CookieConsent from "@/docs/components/cookie-consent/CookieConsent.astro"
 import SkipLink from "@/docs/components/skip-link/SkipLink.astro";
 import siteSettings from "@/docs/config/siteSettings.json";
 import { getLocaleFromUrl } from "@/docs/js/localeUtils";
+import type { BreadcrumbItem } from "@/js/jsonLD";
 
 import BaseHead from "./BaseHead.astro";
 
@@ -21,9 +22,21 @@ interface Props {
   image?: ImageMetadata;
   noindex?: boolean; // you need to opt-in to no indexing, as it hides the page from search engines
   sectionId?: string;
+  // Per-page TechArticle + BreadcrumbList data (forwarded to <Seo>)
+  structuredData?: {
+    headline?: string;
+    breadcrumbs?: BreadcrumbItem[];
+  };
 }
 
-const { title, description, image, noindex = false, sectionId = "main" } = Astro.props as Props;
+const {
+  title,
+  description,
+  image,
+  noindex = false,
+  sectionId = "main",
+  structuredData,
+} = Astro.props as Props;
 
 const currLocale = getLocaleFromUrl(Astro.url);
 ---
@@ -36,6 +49,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
       description={description}
       image={image ? image : undefined}
       noindex={noindex}
+      structuredData={structuredData}
     />
   </head>
   <body id="body" class="">

--- a/src/docs/layouts/DocsLayout.astro
+++ b/src/docs/layouts/DocsLayout.astro
@@ -7,7 +7,7 @@ import SidebarNav from "@/docs/components/nav/SidebarNav.astro";
 import TableOfContents from "@/docs/components/table-of-contents/TableOfContents.astro";
 import TocLink from "@/docs/components/table-of-contents/TocLink.astro";
 import { siteSettings } from "@/docs/config/siteSettings.json";
-import { getAdjacentPages } from "@/docs/js/docsUtils";
+import { getAdjacentPages, getDocsBreadcrumbs } from "@/docs/js/docsUtils";
 import { getLocaleFromUrl } from "@/docs/js/localeUtils";
 
 import BaseLayoutDocs from "./BaseLayoutDocs.astro";
@@ -33,9 +33,24 @@ const filteredHeadings = headings.filter(
 
 // Get adjacent pages - only from the current section
 const { prev, next } = await getAdjacentPages(doc.id, currLocale, sectionId);
+
+// Per-page structured data: TechArticle headline matches the visible H1
+// (`title`, not the suffixed meta title), plus a validated breadcrumb trail.
+const breadcrumbs = await getDocsBreadcrumbs(
+  doc,
+  sectionId,
+  currLocale,
+  Astro.site?.toString() ?? "",
+);
+const structuredData = { headline: title, breadcrumbs };
 ---
 
-<BaseLayoutDocs title={seoTitle ?? title} description={description} sectionId={sectionId}>
+<BaseLayoutDocs
+  title={seoTitle ?? title}
+  description={description}
+  sectionId={sectionId}
+  structuredData={structuredData}
+>
   <div
     class="docs-site-container min-h-[calc(100vh-var(--nav-height))] flex-1 border-x md:grid md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_240px] lg:gap-10 2xl:grid-cols-[240px_minmax(0,1fr)_280px]"
   >

--- a/src/docs/layouts/DocsLayoutStandalone.astro
+++ b/src/docs/layouts/DocsLayoutStandalone.astro
@@ -9,6 +9,7 @@ import type { MarkdownHeading } from "astro";
 import SidebarNav from "@/docs/components/nav/SidebarNav.astro";
 import TableOfContents from "@/docs/components/table-of-contents/TableOfContents.astro";
 import TocLink from "@/docs/components/table-of-contents/TocLink.astro";
+import type { BreadcrumbItem } from "@/js/jsonLD";
 
 import BaseLayoutDocs from "./BaseLayoutDocs.astro";
 
@@ -19,6 +20,10 @@ interface Props {
   headings?: MarkdownHeading[];
   minHeadingLevel?: number;
   maxHeadingLevel?: number;
+  structuredData?: {
+    headline?: string;
+    breadcrumbs?: BreadcrumbItem[];
+  };
 }
 
 const {
@@ -28,6 +33,7 @@ const {
   headings = [],
   minHeadingLevel = 2,
   maxHeadingLevel = 3,
+  structuredData,
 } = Astro.props;
 
 const filteredHeadings = headings.filter(
@@ -35,7 +41,12 @@ const filteredHeadings = headings.filter(
 );
 ---
 
-<BaseLayoutDocs title={title} description={description} sectionId={sectionId}>
+<BaseLayoutDocs
+  title={title}
+  description={description}
+  sectionId={sectionId}
+  structuredData={structuredData}
+>
   <div
     class="docs-site-container min-h-[calc(100vh-var(--nav-height))] flex-1 border-x md:grid md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_240px] lg:gap-10 2xl:grid-cols-[240px_minmax(0,1fr)_280px]"
   >

--- a/src/js/jsonLD.ts
+++ b/src/js/jsonLD.ts
@@ -18,7 +18,56 @@ export interface BlogProps {
   canonicalUrl: URL;
 }
 
-export type JsonLDProps = BlogProps | GeneralProps;
+/** One entry in a BreadcrumbList. The final (current page) crumb may omit `item`. */
+export interface BreadcrumbItem {
+  name: string;
+  item?: string;
+}
+
+export interface DocsProps {
+  type: "docs";
+  headline: string; // should match the page's visible H1
+  description?: string;
+  canonicalUrl: URL;
+  breadcrumbs: BreadcrumbItem[];
+}
+
+export type JsonLDProps = BlogProps | GeneralProps | DocsProps;
+
+const getBaseUrl = () => import.meta.env.SITE?.replace(/\/$/, "") ?? "";
+
+/** Organization entity reused across the site graphs (publisher / author ref) */
+function buildOrganization(baseUrl: string) {
+  return {
+    "@type": "Organization",
+    "@id": `${baseUrl}/#organization`,
+    name: siteData.name,
+    url: baseUrl,
+    description: siteData.description,
+    logo: {
+      "@type": "ImageObject",
+      url: `${baseUrl}${siteData.defaultImage.src.startsWith("/") ? "" : "/"}${siteData.defaultImage.src}`,
+    },
+    // Entity consolidation for knowledge graphs / answer engines
+    sameAs: [
+      "https://github.com/getplumber",
+      "https://www.linkedin.com/company/getplumber",
+      "https://x.com/getplumber_io",
+    ],
+  };
+}
+
+/** WebSite entity reused across the site graphs */
+function buildWebSite(baseUrl: string, organizationId: string) {
+  return {
+    "@type": "WebSite",
+    "@id": `${baseUrl}/#website`,
+    name: siteData.title,
+    url: baseUrl,
+    description: siteData.description,
+    publisher: { "@id": organizationId },
+  };
+}
 
 export default function jsonLDGenerator(props: JsonLDProps) {
   const { type } = props;
@@ -71,33 +120,58 @@ export default function jsonLDGenerator(props: JsonLDProps) {
 
     return `<script type="application/ld+json">${JSON.stringify(blogPosting)}</script>`;
   }
+
+  if (type === "docs") {
+    // Per-page TechArticle + BreadcrumbList for documentation pages, bundled
+    // into one @graph with the site Organization/WebSite so the entities
+    // cross-reference (publisher, isPartOf). Big ranking signal for tool docs.
+    const { headline, description, canonicalUrl, breadcrumbs } = props as DocsProps;
+    const baseUrl = getBaseUrl();
+    const organization = buildOrganization(baseUrl);
+    const webSite = buildWebSite(baseUrl, organization["@id"] as string);
+    const pageUrl = canonicalUrl.toString();
+
+    const techArticle: Record<string, unknown> = {
+      "@type": "TechArticle",
+      "@id": `${pageUrl}#article`,
+      headline,
+      inLanguage: "en",
+      url: pageUrl,
+      mainEntityOfPage: { "@type": "WebPage", "@id": pageUrl },
+      isPartOf: { "@id": webSite["@id"] },
+      author: { "@id": organization["@id"] },
+      publisher: { "@id": organization["@id"] },
+    };
+    if (description) {
+      techArticle["description"] = description;
+    }
+
+    const breadcrumbList = {
+      "@type": "BreadcrumbList",
+      "@id": `${pageUrl}#breadcrumb`,
+      // Each non-final crumb must carry a resolvable `item` URL (Google
+      // flags missing items); the current page is the final crumb.
+      itemListElement: breadcrumbs.map((crumb, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: crumb.name,
+        ...(crumb.item ? { item: crumb.item } : {}),
+      })),
+    };
+
+    const docsGraph = [organization, webSite, techArticle, breadcrumbList];
+    // Escape "<" so embedded text can't break the <script> block and so
+    // @playform/compress can process the output (see SoftwareAppJsonLd).
+    return `<script type="application/ld+json">${JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": docsGraph,
+    }).replace(/</g, "\\u003c")}</script>`;
+  }
+
   // Organization + WebSite for SEO and AEO (answer engines use entity markup)
-  const baseUrl = import.meta.env.SITE?.replace(/\/$/, "") ?? "";
-  const organization = {
-    "@type": "Organization",
-    "@id": `${baseUrl}/#organization`,
-    name: siteData.name,
-    url: baseUrl,
-    description: siteData.description,
-    logo: {
-      "@type": "ImageObject",
-      url: `${baseUrl}${siteData.defaultImage.src.startsWith("/") ? "" : "/"}${siteData.defaultImage.src}`,
-    },
-    // Entity consolidation for knowledge graphs / answer engines
-    sameAs: [
-      "https://github.com/getplumber",
-      "https://www.linkedin.com/company/getplumber",
-      "https://x.com/getplumber_io",
-    ],
-  };
-  const webSite = {
-    "@type": "WebSite",
-    "@id": `${baseUrl}/#website`,
-    name: siteData.title,
-    url: baseUrl,
-    description: siteData.description,
-    publisher: { "@id": organization["@id"] },
-  };
+  const baseUrl = getBaseUrl();
+  const organization = buildOrganization(baseUrl);
+  const webSite = buildWebSite(baseUrl, organization["@id"] as string);
   const graph = [organization, webSite];
   return `<script type="application/ld+json">${JSON.stringify({ "@context": "https://schema.org", "@graph": graph })}</script>`;
 }

--- a/src/pages/docs/[section]/issues/[code].astro
+++ b/src/pages/docs/[section]/issues/[code].astro
@@ -260,6 +260,20 @@ function configKeyExample(provider: Provider, configKey: string): string {
   }
   return `gitlab:\n  controls:\n    ${configKey}:\n      enabled: true`;
 }
+
+// Per-page structured data: BreadcrumbList mirrors the visible breadcrumb
+// (Controls → Issues → CODE) with absolute, resolvable URLs, prefixed by Home.
+// TechArticle headline matches the default provider's visible H1.
+const siteBase = (Astro.site?.toString() ?? "").replace(/\/$/, "");
+const structuredData = {
+  headline: defaultPageTitle,
+  breadcrumbs: [
+    { name: "Home", item: `${siteBase}/` },
+    { name: "Controls", item: `${siteBase}${docsBase}/controls` },
+    { name: "Issues", item: `${siteBase}${docsBase}/issues` },
+    { name: code },
+  ],
+};
 ---
 
 <DocsLayoutStandalone
@@ -267,6 +281,7 @@ function configKeyExample(provider: Provider, configKey: string): string {
   description={defaultContent.description}
   sectionId={tabId}
   headings={pageHeadings}
+  structuredData={structuredData}
 >
   <!-- Breadcrumb (shared across providers) -->
   <Breadcrumb class="mb-4 text-xs md:text-sm">


### PR DESCRIPTION
Docs pages previously emitted only the generic Organization + WebSite graph (identical on every page). Add per-page structured data — the high-value markup for tool documentation:

- TechArticle (headline = visible H1, description, canonical url, isPartOf WebSite, author/publisher Organization)
- BreadcrumbList (Home -> Section -> Page; issue pages mirror the visible Controls -> Issues -> CODE trail)

Everything is bundled into a single cross-referenced @graph alongside Organization/WebSite. Validity guards (broken markup gets pages dropped from rich results): section crumbs link only to landing pages that actually exist, no fabricated dates, headline matches the H1, absolute URLs, and "<" escaped so @playform/compress can process the output.