### PR TITLE
chore(docs): point GitHub Action link to Marketplace listing

### DIFF
--- a/src/docs/data/docs/en/cli/github/index.mdx
+++ b/src/docs/data/docs/en/cli/github/index.mdx
@@ -82,7 +82,7 @@ Best for trying Plumber on one repo, checks before you push, security-team audit
 
    <Aside variant="tip">
 
-   - **Pin by commit SHA, not a tag.** Copy the ready-to-paste SHA-pinned `uses:` line from the [GitHub Action section of the README](https://github.com/getplumber/plumber#option-3-github-action), auto-updated on new releases.
+   - **Pin by commit SHA, not a tag.** Copy the ready-to-paste SHA-pinned `uses:` line from the [Plumber Action on the GitHub Marketplace](https://github.com/marketplace/actions/plumber-security), auto-updated on new releases.
    - **Permissions.** The job needs `security-events: write` for SARIF upload to Code Scanning; without it that step is skipped. Add `id-token: write` to publish a live score badge.
    - **Publish a live score badge.** Set `score-push: true` to publish a **public** Plumber Score badge for this repo. See [Plumber Score](/docs/plumber-score).
 


### PR DESCRIPTION
## Summary

The Plumber GitHub Action now has a Marketplace listing. This updates the docs reference to point there instead of the README anchor.

The listing name is **"Plumber Security"** — the bare name "Plumber" can't be used because it collides with the existing `github.com/plumber` account, which GitHub Marketplace rejects. The Marketplace slug is therefore `plumber-security`.

## Changes

- `src/docs/data/docs/en/cli/github/index.mdx`: the "Run with GitHub Actions" tip now links to the [Plumber Action on the GitHub Marketplace](https://github.com/marketplace/actions/plumber-security) instead of `getplumber/plumber#option-3-github-action`.

This was the only external reference to the Action's home in the repo — all other "GitHub Action" mentions are internal `/docs/cli/github` links or workflow `uses:` snippets, which are unchanged. The `uses: getplumber/plumber@<sha>` reference is unaffected by the listing name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)