### PR TITLE
fix(hero): show GitHub stars/version badge as skeleton until loaded

### DIFF
--- a/src/components/Hero/GitHubHeroStatsBadge.astro
+++ b/src/components/Hero/GitHubHeroStatsBadge.astro
@@ -8,7 +8,7 @@ import { Icon } from "astro-icon/components";
 
 <div
   id="gh-hero-stats-badge"
-  class="bg-base-100/70 dark:bg-base-800/70 border-primary-500/30 ring-primary-500/15 mx-auto hidden w-max flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border px-4 py-2 text-sm ring-1 sm:gap-x-4"
+  class="bg-base-100/70 dark:bg-base-800/70 border-primary-500/30 ring-primary-500/15 mx-auto inline-flex w-max flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border px-4 py-2 text-sm ring-1 sm:gap-x-4"
   data-mos="fade-up"
   data-mos-delay="0.3"
   data-mos-anchor="#plumber-hero"
@@ -23,7 +23,11 @@ import { Icon } from "astro-icon/components";
     <Icon name="tabler/brand-github" class="h-4 w-4 shrink-0" aria-hidden="true" />
     <span class="inline-flex items-center gap-1.5" data-gh-stars-wrap>
       <Icon name="tabler/star-filled" class="h-4 w-4 text-amber-400" aria-hidden="true" />
-      <span id="gh-stars" class="tabular-nums text-xs"></span>
+      <span id="gh-stars" class="tabular-nums text-xs"
+        ><span
+          class="gh-skel inline-block h-3 w-7 animate-pulse rounded bg-base-400/40 dark:bg-base-500/40 align-middle"
+          aria-hidden="true"></span
+      ></span>
       <span>stars</span>
     </span>
   </a>
@@ -40,7 +44,11 @@ import { Icon } from "astro-icon/components";
     data-gh-release-wrap
   >
     <Icon name="tabler/tag" class="h-4 w-4 shrink-0" aria-hidden="true" />
-    <span id="gh-release" class="min-w-[2.5rem] font-mono text-xs tracking-tight"></span>
+    <span id="gh-release" class="min-w-[2.5rem] font-mono text-xs tracking-tight"
+      ><span
+        class="gh-skel inline-block h-3 w-12 animate-pulse rounded bg-base-400/40 dark:bg-base-500/40 align-middle"
+        aria-hidden="true"></span
+    ></span>
   </a>
 </div>
 

--- a/src/js/githubHeroStats.ts
+++ b/src/js/githubHeroStats.ts
@@ -8,8 +8,11 @@ const HEADERS: HeadersInit = {
 };
 
 /**
- * Fetches hero GitHub stars and latest release in the browser, then shows the badge only
- * when at least one value is available. No auth token. Uses textContent only.
+ * Fetches hero GitHub stars and latest release in the browser. The badge is
+ * rendered up-front with skeleton placeholders (so it reserves its space and
+ * does not shift the hero when data arrives); this fills in the real values,
+ * hides a half that failed, and only collapses the whole badge if both fail.
+ * No auth token. Uses textContent only.
  */
 export function initGitHubHeroStats(): void {
   void run();
@@ -64,8 +67,12 @@ async function run(): Promise<void> {
   }
 
   if (starsOk || releaseOk) {
-    badgeEl.classList.remove("hidden");
-    badgeEl.classList.add("inline-flex");
+    // The badge is visible from first paint (skeleton); setting textContent above
+    // already swapped the placeholders for real values — just expose it to a11y.
     badgeEl.removeAttribute("aria-hidden");
+  } else {
+    // Both lookups failed (offline / rate-limited): collapse the placeholder
+    // instead of leaving skeletons up indefinitely.
+    badgeEl.classList.add("hidden");
   }
 }


### PR DESCRIPTION
The badge was display:none until the GitHub API responded, then appeared and pushed the hero content down (looked like a layout-shift bug). Render it from first paint with shimmer skeleton placeholders so it reserves its space; the fetched stars count and CLI version swap in with no shift. Only collapse the badge if both lookups fail.