### PR TITLE
docs(plumber-score): simplify grade table and move points to scoring section

### DIFF
--- a/src/docs/data/docs/en/plumber-score/index.mdx
+++ b/src/docs/data/docs/en/plumber-score/index.mdx
@@ -18,13 +18,13 @@ Plumber Score is a simple **A-E** grade for your CI/CD security. The
 open-source [Plumber CLI](https://github.com/getplumber/plumber) produces it on
 **every run**, whether you run it locally or in your CI pipeline.
 
-| Grade | Points | What it means |
-|:-----:|:------:|---------------|
-| <span class="font-bold text-primary-400 dark:text-primary-300">A</span> | ≥ 90 | **Excellent**: very low risk, clean pipeline |
-| <span class="font-bold text-primary-400 dark:text-primary-300">B</span> | 71 – 89 | **Good**: a few Low or Medium issues |
-| <span class="font-bold text-yellow-500 dark:text-yellow-400">C</span> | 51 – 70 | **Moderate**: Medium issues or accumulating Low findings, worth fixing |
-| <span class="font-bold text-orange-500 dark:text-orange-400">D</span> | 31 – 50 | **Poor**: High-severity issues impacting the pipeline |
-| <span class="font-bold text-red-400 dark:text-red-300">E</span> | < 31 | **Critical**: at least one Critical issue, or heavy accumulated losses |
+| Grade | What it means |
+|:-----:|---------------|
+| <span class="font-bold text-primary-400 dark:text-primary-300">A</span> | **Excellent**: very low risk, clean pipeline |
+| <span class="font-bold text-primary-400 dark:text-primary-300">B</span> | **Good**: a few Low or Medium issues |
+| <span class="font-bold text-yellow-500 dark:text-yellow-400">C</span> | **Moderate**: Medium issues or accumulating Low findings, worth fixing |
+| <span class="font-bold text-orange-500 dark:text-orange-400">D</span> | **Poor**: High-severity issues impacting the pipeline |
+| <span class="font-bold text-red-400 dark:text-red-300">E</span> | **Critical**: at least one Critical issue, or heavy accumulated losses |
 
 ## Publish your score
 
@@ -459,7 +459,15 @@ with the correct workflow `permissions` and `score-push` enabled in the action
 The Plumber CLI determines the score on each run, locally or in CI. Every run
 starts at a perfect **100 points**. Plumber scans your CI/CD configuration, and
 each open issue subtracts points based on its **severity**. The final point
-total maps to the A-E grade above (higher points = better grade).
+total then maps to the A-E grade (higher points = better grade):
+
+| Grade | Points |
+|:-----:|:------:|
+| <span class="font-bold text-primary-400 dark:text-primary-300">A</span> | ≥ 90 |
+| <span class="font-bold text-primary-400 dark:text-primary-300">B</span> | 71 – 89 |
+| <span class="font-bold text-yellow-500 dark:text-yellow-400">C</span> | 51 – 70 |
+| <span class="font-bold text-orange-500 dark:text-orange-400">D</span> | 31 – 50 |
+| <span class="font-bold text-red-400 dark:text-red-300">E</span> | < 31 |
 
 Each severity has a weight, and repeated occurrences of the *same* issue taper
 off (capped) so a single noisy problem can't dominate the whole score:


### PR DESCRIPTION
## What

Update the **Plumber Score** docs page (`/docs/plumber-score`):

- **"What is a Plumber Score?"** — remove the **Points** column from the grade table. At this point in the page, readers haven't been told what points are, so the intro now stays simple: just the A–E grade and what each means.
- **"How is the score determined?"** — introduce the points notion here, where the 0–100 point model is explained, and add the grade-to-points mapping table (A ≥ 90, B 71–89, C 51–70, D 31–50, E < 31).

## Notes

Point thresholds and weights are unchanged and match the `scoring-v3` profile documented in [`getplumber/plumber` `docs/scoring.md`](https://github.com/getplumber/plumber/blob/main/docs/scoring.md). No values were guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)