### PR TITLE
docs(cli): remove compliance wording and default score-push example to false

### DIFF
--- a/src/docs/data/docs/en/cli/github/index.mdx
+++ b/src/docs/data/docs/en/cli/github/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "GitHub"
-seoTitle: "GitHub Actions Security & Compliance Scanning - Plumber CLI"
-description: "Scan GitHub Actions workflows for security and compliance with the open-source Plumber CLI and GitHub Action: authentication, GitHub controls catalog, issues, SARIF and Code Scanning."
+seoTitle: "GitHub Actions Security Scanning - Plumber CLI"
+description: "Scan GitHub Actions workflows for security with the open-source Plumber CLI and GitHub Action: authentication, GitHub controls catalog, issues, SARIF and Code Scanning."
 sidebar:
   label: "GitHub"
   order: 3
@@ -87,7 +87,7 @@ Best for trying Plumber on one repo, checks before you push, security-team audit
    </Aside>
 
    ```yaml
-   name: Plumber compliance
+   name: Plumber
 
    on:
      push:
@@ -106,7 +106,7 @@ Best for trying Plumber on one repo, checks before you push, security-team audit
          - uses: actions/checkout@v6
          - uses: getplumber/plumber@COMMIT_SHA
            with:
-             score-push: true # if "true": publish a public Plumber Score badge
+             score-push: false # set to "true" to publish a public Plumber Score badge
    ```
 
 3. **Push and check results**: findings appear in the **Code Scanning** tab, the job summary, and the downloadable artifact bundle.
@@ -138,7 +138,7 @@ Override any input to fit your needs:
 | `metadata-token` | - | Optional token (public-repo read) used only to resolve third-party action versions for the known-CVE check, when an action is hosted in an org with an IP allow list that blocks the runner's `GITHUB_TOKEN`. Falls back to an anonymous read when unset |
 | `project` | _(current repo)_ | `owner/repo` to scan remotely (upstream-fetch, no checkout needed) |
 | `github-url` | _(github.com)_ | GitHub Enterprise Server host (e.g. `ghes.example.com`) |
-| `threshold` | `100` | Minimum compliance percentage to pass (0-100) |
+| `threshold` | `100` | Minimum passing percentage (0-100) |
 | `config-file` | _(auto-detect)_ | Path to `.plumber.yaml`. Defaults to repo root; the run fails if absent |
 | `controls` | - | Run only these controls (comma-separated). Mutually exclusive with `skip-controls` |
 | `skip-controls` | - | Skip these controls (comma-separated). Mutually exclusive with `controls` |
@@ -146,7 +146,7 @@ Override any input to fit your needs:
 | `score-push` | `false` | Publish this repo's Plumber Score to the hosted badge service ([score.getplumber.io](https://score.getplumber.io)) via CI-native OIDC (**no secret**). The workflow MUST grant `permissions: id-token: write`. Publishes on every run; the service keeps only the default branch for the public badge. Warns (never fails) on error. See [Plumber Score](/docs/plumber-score) |
 | `score-endpoint` | `https://score.getplumber.io` | Score service base URL. Override **only** for a self-hosted score service; the OIDC audience follows this value so it always matches the target |
 | `fail-warnings` | `false` | Fail on warnings: unknown configuration keys (exit 2) and "could not verify" checks such as a skipped known-CVE lookup (exit 3). `soft-fail` does not mask exit 3 |
-| `soft-fail` | `false` | Do not fail the job when compliance is below the threshold. Findings are still produced and uploaded |
+| `soft-fail` | `false` | Do not fail the job when the result is below the threshold. Findings are still produced and uploaded |
 | `upload-sarif` | `true` | Upload the SARIF report to GitHub Code Scanning |
 | `upload-artifacts` | `true` | Upload JSON report, PBOM, and CycloneDX SBOM as a workflow artifact |
 | `artifact-name` | `plumber-compliance` | Name of the uploaded artifact bundle |
@@ -159,8 +159,8 @@ Override any input to fit your needs:
 
 | Output | Description |
 |--------|-------------|
-| `compliance` | Overall compliance percentage from the run |
-| `passed` | `true` when compliance is at or above the threshold |
+| `compliance` | Overall passing percentage from the run |
+| `passed` | `true` when the percentage is at or above the threshold |
 | `report` | Path to the JSON report |
 | `sarif` | Path to the SARIF report |
 
@@ -169,7 +169,7 @@ Use outputs in downstream steps:
 ```yaml
 - uses: getplumber/plumber@COMMIT_SHA   # vX.Y.Z
   id: plumber
-- run: echo "Compliance is ${{ steps.plumber.outputs.compliance }}%"
+- run: echo "Plumber result is ${{ steps.plumber.outputs.compliance }}%"
 ```
 
 ### Code Scanning integration
@@ -267,7 +267,7 @@ When a token-scoped control cannot fully evaluate, Plumber adds a `partialContro
 ]
 ```
 
-When this array is non-empty, at least one control abstained on at least part of its input. Treat the run as suspect rather than trusting the compliance percentage. On a clean run the array is either omitted or empty.
+When this array is non-empty, at least one control abstained on at least part of its input. Treat the run as suspect rather than trusting the reported percentage. On a clean run the array is either omitted or empty.
 
 ### Running a scan
 
@@ -317,7 +317,7 @@ The CLI output is color-coded in your terminal for easy scanning: green for pass
   When using `--output`, results are saved as JSON for programmatic access and CI/CD integration.
 </Aside>
 
-![Plumber CLI output showing compliance results](../img/cli-gh-output.png)
+![Plumber CLI output showing analysis results](../img/cli-gh-output.png)
 
 ### Example Configuration
 

--- a/src/docs/data/docs/en/cli/gitlab/index.mdx
+++ b/src/docs/data/docs/en/cli/gitlab/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "GitLab"
-seoTitle: "Scan GitLab CI/CD Pipelines for Compliance - Plumber CLI"
-description: "Scan GitLab CI/CD pipelines for security and compliance with the open-source Plumber CLI: authentication, GitLab controls catalog, issues, configuration, and MR/badge integration."
+seoTitle: "Scan GitLab CI/CD Pipelines for Security - Plumber CLI"
+description: "Scan GitLab CI/CD pipelines for security with the open-source Plumber CLI: authentication, GitLab controls catalog, issues, configuration, and MR/badge integration."
 sidebar:
   label: "GitLab"
   order: 4
@@ -111,7 +111,7 @@ Two ways to scan a GitLab project:
 
 5. **Run your pipeline**
 
-   Plumber now runs on every pipeline (default branch, tags, and open merge requests) and reports compliance issues.
+   Plumber now runs on every pipeline (default branch, tags, and open merge requests) and reports issues.
 </Steps>
 
 ### Hosting on self-hosted GitLab
@@ -211,7 +211,7 @@ include:
       branch: develop                            # Analyze a specific branch
       ci_config_path: $CI_CONFIG_PATH            # CI config path (GitLab predefined variable)
 
-      # Compliance
+      # Policy
       threshold: 80                              # Minimum % to pass (default: 100)
       config_file: configs/my-plumber.yaml       # Custom config path
 
@@ -247,7 +247,7 @@ The `controls` / `skip_controls` inputs map to the CLI `--controls` / `--skip-co
 | `branch` | `$CI_COMMIT_REF_NAME` | Branch to analyze |
 | `ci_config_path` | `$CI_CONFIG_PATH` | CI configuration file path to analyze. Defaults to the GitLab predefined variable (`.gitlab-ci.yml` unless customized in project settings) |
 | `gitlab_token` | `$GITLAB_TOKEN` | GitLab API token (`read_api` + `read_repository`, or `api` if `mr_comment` / `badge` is enabled) |
-| `threshold` | `100` | Minimum compliance % to pass |
+| `threshold` | `100` | Minimum passing % |
 | `config_file` | *(auto-detect)* | Path to config file (relative to repo root). Auto-detects `.plumber.yaml`, falls back to default |
 | `output_file` | `plumber-report.json` | Path to write JSON results |
 | `pbom_file` | `plumber-pbom.json` | Path to write the PBOM |
@@ -257,7 +257,7 @@ The `controls` / `skip_controls` inputs map to the CLI `--controls` / `--skip-co
 | `image` | `getplumber/plumber:0.1` | Docker image to use |
 | `allow_failure` | `false` | Allow the job to fail without blocking |
 | `verbose` | `false` | Enable debug output |
-| `mr_comment` | `false` | Post/update a compliance comment on the merge request (requires `api` scope) |
+| `mr_comment` | `false` | Post/update a Plumber comment on the merge request (requires `api` scope) |
 | `badge` | `false` | Create/update a Plumber letter-score badge (requires `api` scope; default branch only) |
 | `score` | `false` | Deprecated no-op. The Plumber score is shown by default now; kept so pipelines that already set it do not break. Use `score_point` for the full points breakdown |
 | `score_point` | `false` | Add the full points breakdown to stdout and the MR comment (the score banner is shown by default) |
@@ -352,7 +352,7 @@ The CLI output is color-coded in your terminal for easy scanning: green for pass
   When using `--output`, results are saved as JSON for programmatic access and CI/CD integration.
 </Aside>
 
-![Plumber CLI output showing compliance results](../img/cli-output.png)
+![Plumber CLI output showing analysis results](../img/cli-output.png)
 
 ### Configuration
 
@@ -506,11 +506,11 @@ gitlab:
 
 ## GitLab Integration
 
-Plumber integrates directly with GitLab to provide visual compliance feedback where your team works.
+Plumber integrates directly with GitLab to provide visual feedback where your team works.
 
 ### Merge Request Comments
 
-Automatically post compliance summaries on merge requests to catch issues before they're merged.
+Automatically post Plumber summaries on merge requests to catch issues before they're merged.
 
 ```bash
 plumber analyze --mr-comment
@@ -525,11 +525,11 @@ include:
       mr_comment: true  # Requires api scope on token
 ```
 
-![Merge request comment showing compliance results](../img/merge-request-comments.png)
+![Merge request comment showing Plumber results](../img/merge-request-comments.png)
 
 **Features:**
 - Shows the Plumber letter-score badge (A–E) and a short score line; with `score_point`, adds the full points breakdown
-- Lists all controls with individual compliance percentages
+- Lists all controls with individual passing percentages
 - Details specific issues found with job names and image references
 - Automatically updates on each pipeline run (no duplicate comments)
 

--- a/src/docs/data/docs/en/cli/index.mdx
+++ b/src/docs/data/docs/en/cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Source CLI"
-seoTitle: "Plumber CLI - Open Source CI/CD Compliance Scanner for GitLab & GitHub"
-description: "Plumber is an open-source CLI that audits GitLab CI/CD pipelines and GitHub Actions workflows for security and compliance. One policy file, shared controls, letter-grade reports."
+seoTitle: "Plumber CLI - Open Source CI/CD Security Scanner for GitLab & GitHub"
+description: "Plumber is an open-source CLI that audits GitLab CI/CD pipelines and GitHub Actions workflows for security. One policy file, shared controls, letter-grade reports."
 sidebar:
   label: "Open Source CLI"
   order: 1

--- a/src/docs/data/docs/en/cli/installation.mdx
+++ b/src/docs/data/docs/en/cli/installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Installation"
 seoTitle: "Install the Plumber CLI - Homebrew, mise, Docker, or Binary"
-description: "Install the open-source Plumber CI/CD compliance CLI on macOS, Linux, or in CI via Homebrew, mise, prebuilt binary, Docker, or build from source."
+description: "Install the open-source Plumber CI/CD security CLI on macOS, Linux, or in CI via Homebrew, mise, prebuilt binary, Docker, or build from source."
 sidebar:
   label: "Installation"
   order: 2

--- a/src/docs/data/docs/en/cli/reference/index.mdx
+++ b/src/docs/data/docs/en/cli/reference/index.mdx
@@ -31,7 +31,7 @@ plumber analyze [flags]
 | `--provider` | No | auto-detect | Force the provider: `github` or `gitlab` (overrides auto-detection; the host is still auto-detected). |
 | `--project` | No* | auto-detect | Project / repo path. GitLab: `group/project`. GitHub: `owner/repo`. |
 | `--config` | No | `.plumber.yaml` | Path to configuration file |
-| `--threshold` | No | `100` | Minimum compliance % to pass (0-100) |
+| `--threshold` | No | `100` | Minimum passing % (0-100) |
 | `--branch` | No | Project default | Branch to analyze |
 | `--print` | No | `true` | Print text output to stdout |
 | `--output`, `-o` | No | - | Write JSON results to file |
@@ -39,8 +39,8 @@ plumber analyze [flags]
 | `--pbom-cyclonedx` | No | - | Write PBOM in CycloneDX SBOM format |
 | `--sarif` | No | - | Write SARIF 2.1.0 results to file (for GitHub Code Scanning / GitLab Security Dashboard) |
 | `--glsast` | No | - | Write a GitLab SAST report (`gl-sast-report.json`) for the GitLab Security Dashboard / MR widget |
-| `--mr-comment` | No | `false` | Post/update a compliance comment on the merge request (MR pipelines only; requires `api` scope) |
-| `--badge` | No | `false` | Create/update a Plumber compliance badge on the project (requires `api` scope; only runs on default branch) |
+| `--mr-comment` | No | `false` | Post/update a Plumber comment on the merge request (MR pipelines only; requires `api` scope) |
+| `--badge` | No | `false` | Create/update a Plumber badge on the project (requires `api` scope; only runs on default branch) |
 | `--score` | No | `false` | Show the Plumber score banner (letter, points, bar, severity counts) on stdout, and include points + score in the JSON, PBOM, and CycloneDX output |
 | `--score-point` | No | `false` | Like `--score` plus the full per-issue-code points breakdown in stdout and the MR comment; overrides `--score` when both are set |
 | `--score-push` | No | `false` | Publish this repo's Plumber Score to the hosted badge service. Runs in **CI only** (needs a CI-native OIDC id-token; a local run is a no-op). Publishes on every run; the score service keeps only your default branch for the public badge. See [Plumber Score](/docs/plumber-score) |
@@ -283,8 +283,8 @@ Documentation: https://getplumber.io/docs/use-plumber/issues/ISSUE-412
 
 | Code | Meaning |
 |------|---------|
-| `0` | Passed (compliance ≥ threshold) |
-| `1` | Compliance failure (compliance < threshold) |
+| `0` | Passed (result ≥ threshold) |
+| `1` | Threshold failure (result < threshold) |
 | `2` | Runtime error (config error, network failure, missing token, etc.) |
 | `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |
 
@@ -309,7 +309,7 @@ By default Plumber prints a colorized, human-readable report to your terminal (`
 
 | Format | Flag | Spec / shape | What it's for |
 |--------|------|--------------|---------------|
-| Terminal report | `--print` (default `true`) | Colorized text on stdout | Human-readable summary: per-control compliance, findings, and the optional [score banner](#plumber-analyze) (`--score` / `--score-point`) |
+| Terminal report | `--print` (default `true`) | Colorized text on stdout | Human-readable summary: per-control results, findings, and the optional [score banner](#plumber-analyze) (`--score` / `--score-point`) |
 | JSON report | `--output`, `-o` | Plumber JSON ([structure below](#json-report-structure)) | Full structured result for scripting and CI gates |
 | Native PBOM | `--pbom` | Plumber Pipeline Bill of Materials ([below](#pbom--cyclonedx)) | Detailed inventory of pipeline dependencies (images, components, templates, includes) |
 | CycloneDX SBOM | `--pbom-cyclonedx` | CycloneDX 1.5 (JSON) | Standard SBOM for security tooling such as Grype, Trivy, and Dependency-Track |
@@ -320,8 +320,8 @@ By default Plumber prints a colorized, human-readable report to your terminal (`
 
 | Output | Flag | Notes |
 |--------|------|-------|
-| Merge-request comment | `--mr-comment` | Posts/updates a compliance comment on the GitLab MR. Requires an `api`-scope token; MR pipelines only |
-| Project compliance badge | `--badge` | Creates/updates a Plumber badge on the GitLab project. Requires an `api`-scope token; runs on the default branch only |
+| Merge-request comment | `--mr-comment` | Posts/updates a Plumber comment on the GitLab MR. Requires an `api`-scope token; MR pipelines only |
+| Project badge | `--badge` | Creates/updates a Plumber badge on the GitLab project. Requires an `api`-scope token; runs on the default branch only |
 | Hosted Plumber Score badge | `--score-push` | Publishes this repo's A-E score to the hosted [score service](/docs/plumber-score). CI only (needs a CI-native OIDC id-token); a local run is a no-op |
 
 <Aside variant="info">
@@ -333,7 +333,7 @@ By default Plumber prints a colorized, human-readable report to your terminal (`
 `--pbom` writes Plumber's native, pipeline-specific inventory; `--pbom-cyclonedx` writes the same inventory as a [CycloneDX 1.5](https://cyclonedx.org/docs/1.5/json/) SBOM, compatible with tools like Grype, Trivy, and Dependency-Track. With the [GitLab CI component](/docs/cli/gitlab#run-with-the-gitlab-ci-component), the CycloneDX file is automatically uploaded as a [GitLab CycloneDX report](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportscyclonedx).
 
 <Aside variant="info">
-  CI/CD components and templates do not have CVEs in public vulnerability databases. The PBOM is primarily an **inventory and compliance tool**: it tells you *what's in your pipeline*, not whether those items have known vulnerabilities. For image vulnerability scanning, use `trivy image` or `grype` directly on the images.
+  CI/CD components and templates do not have CVEs in public vulnerability databases. The PBOM is primarily an **inventory tool**: it tells you *what's in your pipeline*, not whether those items have known vulnerabilities. For image vulnerability scanning, use `trivy image` or `grype` directly on the images.
 </Aside>
 
 
@@ -356,7 +356,7 @@ By default Plumber prints a colorized, human-readable report to your terminal (`
 | `ciErrors` | array | CI configuration parse errors reported by the provider. Omitted when none. |
 | `pipelineOriginMetrics` | object | Counts and origins of pipeline jobs (hardcoded, from include, from component). |
 | `pipelineImageMetrics` | object | Counts of container images per source / registry. |
-| `compliance` | number | Effective compliance percentage (0–100). |
+| `compliance` | number | Effective passing percentage (0–100). |
 | `threshold` | number | Threshold from `--threshold` (default 100). |
 | `passed` | boolean | True when `compliance >= threshold`. |
 | `plumberScore` | object | Scored severity summary (raw points, severity buckets, final points). Present with `--score` / `--score-point`. |
@@ -375,7 +375,7 @@ Each `*Result` block has the same baseline shape. Some controls add a few contro
 |-----|------|-------------|
 | `issues` | array | Findings raised by the control. Each entry carries an `ISSUE-XXX` code, severity, location, and message. |
 | `metrics` | object | Counts the control collected (jobs scanned, images checked, branches inspected, etc.). |
-| `compliance` | number | Per-control compliance percentage. |
+| `compliance` | number | Per-control passing percentage. |
 | `skipped` | boolean | True when the control was disabled in `.plumber.yaml` or excluded via `--skip-controls`. |
 | `ciValid` | boolean | Same as the top-level field, scoped to what this control needed. |
 | `ciMissing` | boolean | Same as the top-level field, scoped to what this control needed. |


### PR DESCRIPTION
## Summary

Reword the CLI docs (`src/docs/data/docs/en/cli/`) to drop the "compliance" framing:

- The GitHub quickstart workflow example now uses `score-push: false` (with a comment explaining how to opt in) and is named `plumber` instead of `Plumber compliance`.
- Removed the word "compliance" from all prose: SEO titles/descriptions now say "security", threshold descriptions say "minimum passing percentage", MR comments are "Plumber comments", exit code 1 is "Threshold failure", the PBOM is an "inventory tool", and image alt texts were reworded.

Kept untouched because they are the tool's actual API surface: the JSON report field `compliance`, the GitHub Action output `outputs.compliance`, and the default artifact name `plumber-compliance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)