### PR TITLE
docs(issues): render UI-based fixes as numbered steps

### DIFF
--- a/src/data/issues.ts
+++ b/src/data/issues.ts
@@ -25,6 +25,16 @@ export type FixDuration =
 export type ProductScope = "all" | "cli" | "platform";
 export type ControlStatus = "shipping" | "roadmap" | "removed";
 
+/**
+ * One ordered step in a UI / click-through remediation. `title` is the action
+ * to take; `detail` holds optional sub-settings or caveats. Both fields
+ * support the inline-markdown subset (`code`, **bold**, [links](…)).
+ */
+export interface RemediationStep {
+  title: string;
+  detail?: string;
+}
+
 export interface IssueProviderContent {
   title: string;
   category: string;
@@ -43,12 +53,26 @@ export interface IssueProviderContent {
   descriptionPoints?: string[];
   impact: string;
   remediation: string;
-  /** YAML/config example showing the problematic configuration */
-  badExample: string;
-  badExampleCaption: string;
-  /** YAML/config example showing the fixed configuration */
-  goodExample: string;
-  goodExampleCaption: string;
+  /**
+   * Structured, ordered fix instructions rendered as a numbered list in the
+   * "How to fix" section. Use this for UI / click-through fixes where a
+   * config example would be misleading (e.g. toggling settings in the
+   * GitHub/GitLab web UI). Each step has a `title` (the action) and an
+   * optional `detail` (sub-settings, caveats). Both support inline `code`,
+   * **bold**, and [links](…). When set, the `remediation` string is treated
+   * as a short intro sentence above the list.
+   */
+  remediationSteps?: RemediationStep[];
+  /**
+   * YAML/config example showing the problematic configuration. Optional:
+   * omit (together with `goodExample`) when the fix is UI-based and a config
+   * diff would be misleading. Use `remediationSteps` instead.
+   */
+  badExample?: string;
+  badExampleCaption?: string;
+  /** YAML/config example showing the fixed configuration. Optional; see `badExample`. */
+  goodExample?: string;
+  goodExampleCaption?: string;
   /** Additional tips or notes */
   tips: string[];
   /**
@@ -1279,38 +1303,42 @@ branchMustBeProtected:
       impact:
         "Without protection on the matching branches, anyone with write access can push directly, force-push, rewrite history, or delete the branch. Required reviews, code-owner approvals, and status checks are all bypassed.",
       remediation:
-        "Add protection through either mechanism. Classic Branch Protection lives under Settings > Branches; Repository Rulesets live under Settings > Rules > Rulesets (rulesets inherited from the organization count too). Plumber merges all sources, stricter wins, so a rule defined in one mechanism contributes to the effective configuration even if the other has nothing for the same branch.",
-      badExample: `# GitHub repo settings: ❌ No protection on \`main\`
-# Settings > Rules > Rulesets:
-#   (no ruleset targeting \`main\`)
-#
-# Anyone with Write access can:
-#   - push directly to \`main\`
-#   - force-push and rewrite history
-#   - delete the branch
-
-# .plumber.yaml
-github:
-  controls:
-    branchMustBeProtected:
-      enabled: true
-      namePatterns: [main, release/*]
-      allowForcePush: false
-      requirePullRequestReviews: true`,
-      badExampleCaption: "`main` has no ruleset; the protection policy is not satisfied.",
-      goodExample: `# GitHub repo settings: ✅ Ruleset enforces review + no force-push
-# Settings > Rules > Rulesets > New branch ruleset:
-#   Target: main
-#   Rules:
-#     - Restrict deletions
-#     - Block force pushes
-#     - Require a pull request before merging
-#         · Required approvals: 1
-#         · Dismiss stale approvals on new push
-#         · Require review from Code Owners
-#     - Require status checks to pass before merging
-#         · build, test, codeql`,
-      goodExampleCaption: "Ruleset enforces review + bans force-push + requires status checks.",
+        "This is a settings change in the GitHub web UI, not a code or `.plumber.yaml` change. The `.plumber.yaml` config only tells Plumber which branches to check. Protect the branch through **either** mechanism: a **Repository Ruleset** (recommended for new setups) or **classic Branch Protection**. Plumber reads both and merges them, so a rule defined in one is enough to satisfy the policy.",
+      remediationSteps: [
+        {
+          title: "Open **Settings > Rules > Rulesets** and click **New branch ruleset**.",
+          detail:
+            "Rulesets are the modern mechanism and are recommended here. Prefer the classic UI instead? Use **Settings > Branches > Add branch ruleset**, where the settings below map one-to-one.",
+        },
+        {
+          title: "Name the ruleset and set **Enforcement status** to **Active**.",
+          detail:
+            "Disabled and evaluate-mode rulesets are ignored by Plumber; only an active ruleset counts as protection.",
+        },
+        {
+          title: "Under **Target branches**, add every branch this policy covers.",
+          detail:
+            "Match the branches in your `namePatterns` (for example `main` and `release/*`). Use **Include by pattern** for wildcards like `release/*`.",
+        },
+        {
+          title: "Enable **Restrict deletions** and **Block force pushes**.",
+          detail: "This stops the branch from being deleted or having its history rewritten.",
+        },
+        {
+          title: "Enable **Require a pull request before merging**.",
+          detail:
+            "Set **Required approvals** to at least 1, tick **Dismiss stale pull request approvals when new commits are pushed**, and, if you use a `CODEOWNERS` file, **Require review from Code Owners**.",
+        },
+        {
+          title: "Optionally enable **Require status checks to pass** and add your checks.",
+          detail: "For example `build`, `test`, and `codeql`, so failing pipelines can't be merged.",
+        },
+        {
+          title: "Click **Create** to save the ruleset.",
+          detail:
+            "Re-run Plumber to confirm the finding clears. The branch is now protected and the policy is satisfied.",
+        },
+      ],
       tips: [
         "Plumber needs `Administration: Read` (fine-grained PAT) or `repo` scope (classic) to read protection rules at all. Without it the rule reports `partialControls` (abstain), not a pass.",
         "Classic Branch Protection and Rulesets are unioned. A code-owner-approval rule defined only in a Ruleset (no classic rule for the same branch) is still seen.",

--- a/src/pages/docs/[section]/issues/[code].astro
+++ b/src/pages/docs/[section]/issues/[code].astro
@@ -452,37 +452,63 @@ const structuredData = {
             <h2 class="docs-h2 text-xl font-semibold text-foreground mb-3 flex items-center gap-2">
               <span>🔧</span> How to fix
             </h2>
-            <p class="text-foreground/80 leading-relaxed mb-6" set:html={inlineCodeToHtml(c.remediation)} />
+            <p
+              class:list={["text-foreground/80 leading-relaxed", c.remediationSteps && c.remediationSteps.length > 0 ? "mb-5" : "mb-6"]}
+              set:html={inlineCodeToHtml(c.remediation)}
+            />
 
-            <div class="mb-6">
-              <div class="inline-block ">
-                <span
-                  class="shrink-0 mr-1 inline-block items-center rounded px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 ring-1 ring-red-300 dark:ring-red-800/50"
-                  >✗ Before</span
-                >
-                <span class="text-sm text-muted-foreground">{c.badExampleCaption}</span>
-              </div>
-              <ExpressiveCode
-                code={c.badExample}
-                lang="yaml"
-                class="overflow-x-auto rounded-lg text-sm leading-relaxed"
-              />
-            </div>
+            {c.remediationSteps && c.remediationSteps.length > 0 && (
+              <ol class="mb-6 list-none space-y-4 pl-0">
+                {c.remediationSteps.map((step, i) => (
+                  <li class="flex items-start gap-3">
+                    <span class="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-xs font-semibold text-emerald-700 dark:text-emerald-400 ring-1 ring-emerald-300 dark:ring-emerald-700/50">
+                      {i + 1}
+                    </span>
+                    <div class="flex-1 min-w-0">
+                      <p class="text-foreground leading-relaxed" set:html={inlineCodeToHtml(step.title)} />
+                      {step.detail && (
+                        <p
+                          class="mt-1 text-sm text-muted-foreground leading-relaxed"
+                          set:html={inlineCodeToHtml(step.detail)}
+                        />
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
 
-            <div class="mb-6">
-              <div class="inline-block">
-                <span
-                  class="shrink-0 mr-1 inline-block items-center rounded px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-1 ring-emerald-300 dark:ring-emerald-800/50"
-                  >✓ After</span
-                >
-                <span class="text-sm text-muted-foreground">{c.goodExampleCaption}</span>
+            {c.badExample && (
+              <div class="mb-6">
+                <div class="inline-block ">
+                  <span
+                    class="shrink-0 mr-1 inline-block items-center rounded px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 ring-1 ring-red-300 dark:ring-red-800/50"
+                  >✗ Before</span>
+                  <span class="text-sm text-muted-foreground">{c.badExampleCaption}</span>
+                </div>
+                <ExpressiveCode
+                  code={c.badExample}
+                  lang="yaml"
+                  class="overflow-x-auto rounded-lg text-sm leading-relaxed"
+                />
               </div>
-              <ExpressiveCode
-                code={c.goodExample}
-                lang="yaml"
-                class="overflow-x-auto rounded-lg text-sm leading-relaxed"
-              />
-            </div>
+            )}
+
+            {c.goodExample && (
+              <div class="mb-6">
+                <div class="inline-block">
+                  <span
+                    class="shrink-0 mr-1 inline-block items-center rounded px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 ring-1 ring-emerald-300 dark:ring-emerald-800/50"
+                  >✓ After</span>
+                  <span class="text-sm text-muted-foreground">{c.goodExampleCaption}</span>
+                </div>
+                <ExpressiveCode
+                  code={c.goodExample}
+                  lang="yaml"
+                  class="overflow-x-auto rounded-lg text-sm leading-relaxed"
+                />
+              </div>
+            )}
           </section>
 
           {c.tips.length > 0 && (


### PR DESCRIPTION
## Problem

On `/docs/cli/issues/ISSUE-501?p=github`, the **How to fix** section always rendered two YAML Before/After code blocks. But fixing branch protection is a click-through in GitHub's settings UI, not a config change. Those blocks were GitHub menu paths disguised as YAML comments, which is exactly what made the section confusing. The real fix was crammed into a single dense paragraph.

## Changes

- **Data model** (`src/data/issues.ts`): add a `RemediationStep` type and an optional `remediationSteps` field; make `badExample`/`goodExample` (and captions) optional so an issue can omit code blocks when a config diff would mislead.
- **Template** (`[code].astro`): render `remediationSteps` as a clean numbered list when present, and only render the Before/After code blocks when the examples exist. Generic, so any UI-only fix can use this; all other issues are unchanged.
- **ISSUE-501 (github)**: remove the two misleading YAML blocks; rewrite the intro to state plainly it is a web-UI settings change (not a `.plumber.yaml` change), and break the fix into 7 ordered steps with the relevant sub-settings and caveats.

The GitLab panel keeps its YAML examples (that fix genuinely maps to config), so only the GitHub variant changed.

## Verification

- `npx astro check`: no new errors in the changed files (pre-existing errors are all in unrelated `scripts/*.js`).
- `npm run build` succeeds; verified the rendered GitHub panel contains the numbered steps and no code blocks.