### PR TITLE
docs(cli): document the three configuration modes and the finding identity block

### DIFF
--- a/src/docs/data/docs/en/cli/github/index.mdx
+++ b/src/docs/data/docs/en/cli/github/index.mdx
@@ -68,15 +68,7 @@ Best for trying Plumber on one repo, checks before you push, security-team audit
 ## Run with GitHub Actions
 
 <Steps>
-1. **Ensure a `.plumber.yaml` exists** in your repo root. Generate one with the [CLI](/docs/cli/installation) if you have it installed, or download the default:
-
-   ```bash
-   plumber config generate
-   # or:
-   curl -fsSL https://raw.githubusercontent.com/getplumber/plumber/main/defaultConfig/.plumber.yaml -o .plumber.yaml
-   ```
-
-2. **Add the action to your workflow** (e.g. `.github/workflows/plumber.yml`):
+1. **Add the action to your workflow** (e.g. `.github/workflows/plumber.yml`):
 
    <Aside variant="tip">
 
@@ -109,7 +101,28 @@ Best for trying Plumber on one repo, checks before you push, security-team audit
              score-push: false # set to "true" to publish a public Plumber Score badge
    ```
 
-3. **Push and check results**: findings appear in the **Code Scanning** tab, the job summary, and the downloadable artifact bundle.
+2. **Push and check results**: findings appear in the **Code Scanning** tab, the job summary, and the downloadable artifact bundle.
+
+3. **Optionally tune the policy with a `.plumber.yaml`**
+
+   Without one, the action runs Plumber's built-in default policy, so you can stop here. To tune the policy, the recommended way is a small overlay that [extends Plumber's baseline](/docs/cli/reference#configuration) and lists only what you change:
+
+   ```bash
+   plumber config generate --overlay
+   ```
+
+   ```yaml
+   extends: plumber:default
+   version: "2.0"
+
+   github:
+     controls:
+       actionsMustBePinnedByCommitSha:
+         trustedOwners:
+           - myorg
+   ```
+
+   `plumber config generate` (without `--overlay`) writes the full self-contained template instead. See the three configuration modes in the [CLI Reference](/docs/cli/reference#configuration).
 </Steps>
 
 ### Customizing the action
@@ -141,7 +154,7 @@ Override any input to fit your needs:
 | `min-score` | - | Minimum [Plumber Score](/docs/plumber-score) letter to pass (A-E), e.g. `B` fails on C, D, E. The recommended way to gate CI on the score |
 | `min-points` | `100` | Fine-grained gate on score points (0-100). The default (100) fails on any finding; not applied when only `min-score` is set |
 | `threshold` | - | **Deprecated.** Minimum percentage of passing controls (0-100). Use `min-score` / `min-points` instead |
-| `config-file` | _(auto-detect)_ | Path to `.plumber.yaml`. Defaults to repo root; the run fails if absent |
+| `config-file` | _(auto-detect)_ | Path to a `.plumber.yaml`. Default: the repo's `.plumber.yaml` if present, otherwise the [built-in default config](/docs/cli/reference#no-configuration) (zero-config runs work out of the box) |
 | `controls` | - | Run only these controls (comma-separated). Mutually exclusive with `skip-controls` |
 | `skip-controls` | - | Skip these controls (comma-separated). Mutually exclusive with `controls` |
 | `score` | `true` | Include the full points breakdown. The Plumber score is shown by default; set `false` for the banner without the per-issue-code breakdown |
@@ -321,9 +334,10 @@ The CLI output is color-coded in your terminal for easy scanning: green for pass
 
 ### Example Configuration
 
-The `github.controls:` section of a schema v2 `.plumber.yaml`:
+The `github.controls:` section of a schema v2 `.plumber.yaml`. With `extends: plumber:default` on top, this file is an [overlay](/docs/cli/reference#configuration): every control keeps its baseline setting and you list only what you change. Without `extends`, the file is the complete policy and a control left out does not run.
 
 ```yaml
+extends: plumber:default
 version: "2.0"
 
 github:
@@ -541,7 +555,7 @@ github:
       codeOwnerApprovalRequired: true
 ```
 
-See the [full configuration reference](https://github.com/getplumber/plumber/blob/main/defaultConfig/.plumber.yaml) for every option, the [Installation](/docs/cli/installation) page, and the [CLI Reference](/docs/cli/reference) for the provider-agnostic commands and output formats.
+See the [full configuration reference](https://github.com/getplumber/plumber/blob/main/defaultConfig/.plumber.yaml) for every option, the [configuration modes](/docs/cli/reference#configuration) (no config, extended, full) and provider-agnostic commands and output formats in the [CLI Reference](/docs/cli/reference), and the [Installation](/docs/cli/installation) page.
 
 ## Reference
 

--- a/src/docs/data/docs/en/cli/gitlab/index.mdx
+++ b/src/docs/data/docs/en/cli/gitlab/index.mdx
@@ -66,23 +66,15 @@ Two ways to scan a GitLab project:
 ## Run with the GitLab CI component
 
 <Steps>
-1. **Ensure a `.plumber.yaml` exists** in your repo root. Generate one with the [CLI](/docs/cli/installation) if you have it installed, or download the default:
-
-   ```bash
-   plumber config generate
-   # or:
-   curl -fsSL https://raw.githubusercontent.com/getplumber/plumber/main/defaultConfig/.plumber.yaml -o .plumber.yaml
-   ```
-
-2. **Create a GitLab token**
+1. **Create a GitLab token**
 
    Use a token with `read_api` + `read_repository` scopes (or `api` if you enable `mr_comment` / `badge`), as described under [Authentication](#authentication) below.
 
-3. **Add the token to your project**
+2. **Add the token to your project**
 
    Go to **Settings → CI/CD → Variables** and add it as `GITLAB_TOKEN` (masked recommended).
 
-4. **Add the component to your `.gitlab-ci.yml`**
+3. **Add the component to your `.gitlab-ci.yml`**
 
    <Aside variant="info">
 
@@ -109,9 +101,31 @@ Two ways to scan a GitLab project:
 
    Get the latest version from the [CI/CD Catalog](https://gitlab.com/explore/catalog/getplumber/plumber).
 
-5. **Run your pipeline**
+4. **Run your pipeline**
 
    Plumber now runs on every pipeline (default branch, tags, and open merge requests) and reports issues.
+
+5. **Optionally tune the policy with a `.plumber.yaml`**
+
+   Without one, the component runs Plumber's built-in default policy, so you can stop here. To tune the policy, the recommended way is a small overlay that [extends Plumber's baseline](/docs/cli/reference#configuration) and lists only what you change:
+
+   ```bash
+   plumber config generate --overlay
+   ```
+
+   ```yaml
+   extends: plumber:default
+   version: "2.0"
+
+   gitlab:
+     controls:
+       containerImageMustNotUseForbiddenTags:
+         tags:
+           - latest
+           - dev
+   ```
+
+   `plumber config generate` (without `--overlay`) writes the full self-contained template instead. See the three configuration modes in the [CLI Reference](/docs/cli/reference#configuration).
 </Steps>
 
 ### Hosting on self-hosted GitLab
@@ -277,7 +291,7 @@ The component resolves your configuration in priority order:
 2. **`.plumber.yaml` in repo root** uses your repo's config file.
 3. **No config found** uses the [default](https://github.com/getplumber/plumber/blob/main/defaultConfig/.plumber.yaml) embedded in the container.
 
-To author one, run `plumber config generate` (see the [CLI Reference](/docs/cli/reference#command-reference)) or create it manually from the [default config](https://github.com/getplumber/plumber/blob/main/defaultConfig/.plumber.yaml). The CycloneDX SBOM the component writes is automatically uploaded as a [GitLab CycloneDX report](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportscyclonedx).
+To author one, run `plumber config generate --overlay` for a minimal file that [extends Plumber's baseline](/docs/cli/reference#configuration) (recommended), or `plumber config generate` for the full self-contained [default config](https://github.com/getplumber/plumber/blob/main/defaultConfig/.plumber.yaml) (see the [CLI Reference](/docs/cli/reference#command-reference)). The CycloneDX SBOM the component writes is automatically uploaded as a [GitLab CycloneDX report](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportscyclonedx).
 
 
 ## Authentication
@@ -357,9 +371,10 @@ The CLI output is color-coded in your terminal for easy scanning: green for pass
 
 ### Configuration
 
-The `gitlab.controls:` section of a schema v2 `.plumber.yaml`:
+The `gitlab.controls:` section of a schema v2 `.plumber.yaml`. With `extends: plumber:default` on top, this file is an [overlay](/docs/cli/reference#configuration): every control keeps its baseline setting and you list only what you change. Without `extends`, the file is the complete policy and a control left out does not run.
 
 ```yaml
+extends: plumber:default
 version: "2.0"
 
 gitlab:

--- a/src/docs/data/docs/en/cli/index.mdx
+++ b/src/docs/data/docs/en/cli/index.mdx
@@ -16,7 +16,7 @@ Plumber is an open-source CLI that scans your **GitLab CI/CD pipelines** and **G
 - Missing branch protection
 - [More…](/docs/use-plumber/controls)
 
-It turns them into a [Plumber Score](/docs/plumber-score) from <span class="text-primary-400 dark:text-primary-300 font-bold">A</span> to <span class="font-bold text-red-400 dark:text-red-300">E</span> that can block your pipeline below a minimum score you set. Write one `.plumber.yaml` policy and scan both providers.
+It turns them into a [Plumber Score](/docs/plumber-score) from <span class="text-primary-400 dark:text-primary-300 font-bold">A</span> to <span class="font-bold text-red-400 dark:text-red-300">E</span> that can block your pipeline below a minimum score you set. It runs with zero configuration out of the box; to tune the policy, write one `.plumber.yaml` that [extends Plumber's baseline](/docs/cli/reference#configuration) with just what you change, and scan both providers with it.
 
 Pick your platform:
 
@@ -42,4 +42,4 @@ Pick your platform:
   </a>
 </div>
 
-Both providers share one command set and output format. The full **[CLI Reference](/docs/cli/reference)** documents every `analyze` flag, the config commands, exit codes, and the JSON / PBOM / CycloneDX output.
+Both providers share one command set and output format. The full **[CLI Reference](/docs/cli/reference)** documents the three [configuration modes](/docs/cli/reference#configuration) (no config, extended, full), every `analyze` flag, the config commands, exit codes, and the JSON / PBOM / CycloneDX output.

--- a/src/docs/data/docs/en/cli/reference/index.mdx
+++ b/src/docs/data/docs/en/cli/reference/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CLI Reference"
 seoTitle: "Plumber CLI Reference - Commands, Flags, Exit Codes & Output"
-description: "Provider-agnostic reference for the open-source Plumber CLI: the analyze command and flags, config commands, plumber explain, exit codes, PBOM / CycloneDX, and the output JSON shape."
+description: "Provider-agnostic reference for the open-source Plumber CLI: the three configuration modes (zero-config, extends overlay, full file), the analyze command and flags, config commands, plumber explain, exit codes, PBOM / CycloneDX, and the output JSON shape."
 sidebar:
   label: "Reference"
   order: 5
@@ -11,6 +11,53 @@ section: "api"
 ---
 
 The provider-agnostic reference for the Plumber CLI. The `analyze` command takes provider-specific flags and tokens; the config commands, `plumber explain`, exit codes, and output formats behave identically for both GitLab and GitHub. For installation, see the [Installation](/docs/cli/installation) page. For provider specifics, see the [GitHub](/docs/cli/github) and [GitLab](/docs/cli/gitlab) pages.
+
+## Configuration
+
+Plumber reads its policy from `.plumber.yaml` (override the path with `--config`). There are three ways to run it:
+
+| Case | What you write | What runs |
+|------|----------------|-----------|
+| [No configuration](#no-configuration) | Nothing | Plumber's built-in default configuration |
+| [Extended configuration](#extended-configuration-recommended) (**recommended**) | A few-line overlay starting with `extends: plumber:default` | Your overrides, deep-merged onto Plumber's baseline |
+| [Full configuration](#full-configuration) | A complete `.plumber.yaml` without `extends` | Exactly your file; the baseline is not consulted |
+
+### No configuration
+
+`plumber analyze` works with no setup at all. When there is no `.plumber.yaml` and no explicit `--config`, Plumber runs with the default configuration embedded in the binary and prints a one-line notice on stderr. A terminal and a CI job behave identically: there is no interactive prompt. Inspect what runs in this mode with `plumber config view`.
+
+If you pass `--config` and the file does not exist, that is a hard error; Plumber never silently substitutes the default for a file you named.
+
+### Extended configuration (recommended)
+
+Add `extends: plumber:default` to make your `.plumber.yaml` a **sparse overlay** on Plumber's shipped baseline. You write only what you change; everything else is inherited, and new controls Plumber ships in future releases apply automatically without touching your file:
+
+```yaml
+extends: plumber:default
+version: "2.0"
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      includePlumberDefaults: true # keep Plumber's curated trusted orgs (default)
+      trustedGithubActions:
+        - myorg
+```
+
+A section left empty in an overlay inherits the baseline rather than wiping it. On allowlist controls (authorized sources, trusted owners, and so on), `includePlumberDefaults: true` (the default) unions your entries with Plumber's curated list; set it to `false` to use only your own list.
+
+The commands built for this mode:
+
+- [`plumber config generate --overlay`](#plumber-config-generate) writes a minimal overlay starter.
+- [`plumber config resolve`](#plumber-config-resolve) prints the full effective configuration an overlay expands to.
+- [`plumber config view --explain`](#plumber-config-view) shows, per control, whether the value comes from the baseline or your overlay.
+- [`plumber config slim`](#plumber-config-slim) collapses an existing full config into a minimal overlay.
+
+### Full configuration
+
+A `.plumber.yaml` **without** `extends` is a complete, self-contained policy: what is in the file is exactly what runs, and a control you leave out does not run. Nothing is inherited, so new controls Plumber ships stay off until you add them; you own and maintain the whole file (~1000 lines for the complete template).
+
+Author one with [`plumber config generate`](#plumber-config-generate) (the full commented template) or [`plumber config init`](#plumber-config-init) (interactive wizard). This is the right mode when your policy must be fully explicit, with nothing inherited; for auditing, [`plumber config resolve`](#plumber-config-resolve) turns an overlay into an equivalent full file you can commit.
 
 ## Command Reference
 
@@ -75,7 +122,7 @@ Interactive wizard to create a **minimal** `.plumber.yaml`: pick policy areas (c
 
 **Requires an interactive terminal** (TTY). In CI or Docker without a TTY, use [`plumber config generate`](#plumber-config-generate) instead and edit the file.
 
-**Contrast:** [`plumber config generate`](#plumber-config-generate) always writes the **full** default template **with comments**; `init` writes a **short** file shaped by your answers.
+**Contrast:** [`plumber config generate`](#plumber-config-generate) writes the **full** default template **with comments** (or a minimal overlay starter with `--overlay`); `init` writes a **short** file shaped by your answers. Both `init` and the plain `generate` produce a [full configuration](#full-configuration): nothing is inherited from the baseline afterwards.
 
 ```bash
 plumber config init [flags]
@@ -97,6 +144,8 @@ plumber config init -o configs/plumber.yaml
 
 Writes the **official default** `.plumber.yaml`: the full template Plumber ships with, including comments and every control documented inline. Safe for **scripts and CI** (no prompts). Use [`plumber config init`](#plumber-config-init) when you have a TTY and want a **smaller** file with only the checks you pick.
 
+With `--overlay`, writes a minimal [overlay starter](#extended-configuration-recommended) instead: a few commented lines beginning with `extends: plumber:default` that inherit the whole baseline. This is the recommended starting point.
+
 ```bash
 plumber config generate [flags]
 ```
@@ -105,10 +154,12 @@ plumber config generate [flags]
 |------|---------|-------------|
 | `--output`, `-o` | `.plumber.yaml` | Output file path |
 | `--force`, `-f` | `false` | Overwrite existing file |
+| `--overlay` | `false` | Write a minimal overlay starter (`extends: plumber:default`) instead of the full template |
 
 **Examples:**
 
 ```bash
+plumber config generate --overlay
 plumber config generate
 plumber config generate --output my-plumber.yaml
 plumber config generate --force
@@ -158,6 +209,7 @@ plumber config view [flags]
 |------|---------|-------------|
 | `--config`, `-c` | `.plumber.yaml` | Path to configuration file |
 | `--no-color` | `false` | Disable colorized output |
+| `--explain` | `false` | For an [overlay config](#extended-configuration-recommended): also print, per control, whether the value is inherited from `plumber:default` (`base`) or set in your file (`overlay`) |
 
 Booleans are colorized for quick scanning: `true` in green, `false` in red. Color is automatically disabled when piping output.
 
@@ -178,6 +230,53 @@ plumber config view --config custom-plumber.yaml
 
 # View without colors (for piping or scripts)
 plumber config view --no-color
+
+# Show where each control's value comes from (base vs overlay)
+plumber config view --explain
+```
+
+### `plumber config resolve`
+
+Resolve `extends` and `includePlumberDefaults` and print the complete effective `.plumber.yaml`. Use it to see exactly what a scan with an [overlay config](#extended-configuration-recommended) will run, or to materialize an overlay into a full, self-contained file you can commit (nothing left implicit).
+
+With no config file and no `--config`, it prints the built-in default configuration, i.e. what a [zero-config run](#no-configuration) uses.
+
+```bash
+plumber config resolve [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config`, `-c` | `.plumber.yaml` | Path to configuration file |
+| `--output`, `-o` | stdout | Write the resolved config to this file |
+
+**Examples:**
+
+```bash
+plumber config resolve
+plumber config resolve -c overlay.yaml -o full.plumber.yaml
+```
+
+### `plumber config slim`
+
+The inverse of [`plumber config resolve`](#plumber-config-resolve): collapse a full `.plumber.yaml` into a minimal [overlay](#extended-configuration-recommended) that extends `plumber:default`, keeping only the values that differ from the baseline. The right migration path for an existing full config you no longer want to maintain line by line.
+
+The result is a fresh minimal file (comments are not preserved) and it is safe by construction: a control your full config disabled or omitted stays disabled, and a trust list you narrowed stays narrowed; `slim` then `resolve` never widens trust or re-enables a control. Review the output, then commit it.
+
+```bash
+plumber config slim [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config`, `-c` | `.plumber.yaml` | Path to the full configuration file |
+| `--output`, `-o` | stdout | Write the slim overlay to this file |
+
+**Examples:**
+
+```bash
+plumber config slim -o .plumber.yaml
+plumber config slim -c old.yaml -o slim.yaml
 ```
 
 ### `plumber config diff`
@@ -372,7 +471,7 @@ By default Plumber prints a colorized, human-readable report to your terminal (`
 | `warnings` | array | Non-fatal "could not verify" messages (e.g. a known-CVE check that couldn't resolve an action version). Gated by `--fail-warnings` (exit 3). Omitted when none. |
 | `dataCollectionDegraded` | boolean | True when a collection or enrichment step failed mid-run, so the analysis ran on incomplete data. Treat the run as suspect even if it passed its gate. Omitted when false. |
 | `degradedReasons` | array | Human-readable reasons behind `dataCollectionDegraded`. Omitted when not degraded. |
-| `plumberConfig` | object | Self-describing snapshot of the effective policy: `source`, `effectivePolicy` (the parsed config with comments stripped), and `hash` (sha256 of the canonical policy). Written on every run. |
+| `plumberConfig` | object | Self-describing snapshot of the effective policy: `source`, `effectivePolicy` (the parsed config with comments stripped and, for an [overlay config](#extended-configuration-recommended), `extends` fully resolved), and `hash` (sha256 of the canonical policy). Written on every run. |
 
 **Per-control `*Result` block**
 
@@ -397,7 +496,8 @@ Each entry describes one finding. Beyond the keys below, a rule adds its own str
 |-----|------|-------------|
 | `code` | string | The `ISSUE-XXX` code. |
 | `fingerprint` | string | Stable identifier for this finding, for tracking it across runs ([see below](#finding-fingerprint)). |
-| `job` | string | The job, branch, include, or file the finding relates to, depending on the finding type. |
+| `identity` | object | The exact field set the fingerprint is derived from, as data ([see below](#the-identity-block)): `version` (the identity recipe version), `fields` (the ordered key/value pairs), and `subjectFromMessage` (true when the finding still identifies on its message text). |
+| `job` | string | The CI job the finding sits in. Empty when the finding is not about a job: a branch, an include, or a required template / component / action names its subject in the structured payload (`branchName`, `includePath`, `templatePath`, `componentPath`, `requiredAction`, ...) instead. |
 | `step` | string | GitHub only: the workflow step's `name:`, when the author gave the step one. Distinguishes two steps in the same job that reference the same action. Omitted for unnamed steps and on GitLab. |
 | `url` | string | Clickable link to the affected file and line on the provider, or the local path outside CI. |
 | `docUrl` | string | Link to the issue's documentation page. |
@@ -428,7 +528,7 @@ Column order is fixed and will not change:
 | `status` | The control's verdict for this run: `passed`, `failed`, `skipped`, or `error`. Always present. Every row of a failing control carries `failed` |
 | `severity` | `critical`, `high`, `medium`, or `low`. Empty on summary rows |
 | `message` | Finding message on a `failed` row; the skip or error reason on a `skipped` / `error` row; empty on a `passed` row |
-| `context` | The job, branch, include, or file the finding relates to, depending on the finding type. Not always a CI job name, so it isn't called `job` |
+| `context` | The CI job the finding sits in. Empty when the finding is not about a job (a branch, an include, a required template / component / action); those findings name their subject in the JSON report's structured payload and [`identity` block](#the-identity-block) |
 | `file` | Path of the affected file, relative to the repo root. Empty for repo-level findings (e.g. branch protection) |
 | `line` | Line number in `file`. Empty when there's no file, or the finding isn't line-scoped |
 | `url` | Clickable link to the affected file/line on the provider, or the local path outside CI |
@@ -452,10 +552,50 @@ The same value appears in every format, so a finding can be correlated between t
 | GitLab SAST | an `identifiers[]` entry of type `plumber-fingerprint` |
 | OCSF | `fingerprint` on each `unmapped.plumber_findings[]` record |
 
-It is derived from what the finding is *about* rather than how it is worded: the issue code, the file, the job, the subject the rule flagged (an action reference, a branch, an image, a variable), and the workflow step name when there is one. Line numbers are deliberately excluded, so editing unrelated code above a finding does not change its fingerprint.
+It is derived from what the finding is *about* rather than how it is worded: the issue code, the file, the job it sits in when there is one, the subject the rule flagged (an action reference, a branch, an image, a variable, an include path), and the workflow step name when there is one. Line numbers are deliberately excluded, so editing unrelated code above a finding does not change its fingerprint.
 
 For the exact recipe, the subject-key priority, and worked examples of each case (a rule with a structured subject, the same action used twice in one job, the message fallback, repository-level findings), see [docs/FINGERPRINT.md](https://github.com/getplumber/plumber/blob/main/docs/FINGERPRINT.md).
 
 <Aside variant="info">
-  A fingerprint is a tracking identity, not a primary key. Two steps in one job that reference the same action with no `name:` are indistinguishable and share a fingerprint. Group by it; do not assume one row per value.
+  A fingerprint is a tracking identity, not a primary key. Two steps in one job that reference the same action with no `name:` are indistinguishable and share a fingerprint, and a few rules deliberately exclude volatile inputs (a group index, a version ref) so that one unresolved problem does not re-key on every edit. Group by it; do not assume one row per value.
 </Aside>
+
+### The identity block
+
+The fingerprint is a hash, so it cannot tell a consumer *which* fields it was built from. Each issue entry in the JSON report therefore also carries an `identity` block: the selected field set itself, as data.
+
+Every identity carries `code`, `file`, and `job`, then **exactly one subject key** naming what the rule flagged, and finally `step` when the workflow resolved one. Only the single most specific subject key appears, not every field in the finding's payload: the recipe walks a fixed priority list and takes the first key the finding carries.
+
+```json
+"identity": {
+  "version": 2,
+  "subjectFromMessage": false,
+  "fields": [
+    { "key": "code", "value": "ISSUE-701" },
+    { "key": "file", "value": ".github/workflows/build.yaml" },
+    { "key": "job",  "value": "build/compile" },
+    { "key": "uses", "value": "some-org/some-action@master" },
+    { "key": "step", "value": "Build image" }
+  ]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `version` | number | The identity **recipe version** (currently 2). It tracks identity outcomes, not just the algorithm: it is bumped whenever fingerprints can move, so a consumer holding stored fingerprints knows when to expect re-keys. |
+| `subjectFromMessage` | boolean | True when the rule has no structured subject and the finding identifies on its message text, meaning a wording change in a future release would re-key it. False for the vast majority of findings. |
+| `fields` | array | The ordered key/value pairs the fingerprint is derived from. Always `code`, `file`, and `job`; then the one winning **subject key**; then `step` when present (see below). |
+
+**The `fields`, in order:**
+
+| Field | Always present | Description |
+|-------|:--------------:|-------------|
+| `code` | yes | The `ISSUE-XXX` code. |
+| `file` | yes | Affected file, relative to the repo root. Empty for repo-level findings (e.g. branch protection). |
+| `job` | yes | The CI job the finding sits in: `<workflow-file>/<job-id>` on GitHub, the job name on GitLab. **Empty** for findings that are not about a job (a branch, an include, or a required template / component / action), which name their subject in the key below instead. |
+| *(subject)* | yes | Exactly one key naming what the rule flagged, chosen as the first present from this priority order: `uses`, `branchName`, `includePath`, `templatePath`, `componentPath`, `requiredAction`, `image`, `serviceImage`, `link`, `tag`, `variableName`, `hardcodedJob`, `scriptLine`, `detail`. When the rule carries none of them the subject key is `message` and `subjectFromMessage` is `true`. |
+| `step` | no | GitHub only: the workflow step's `name:`, when the author gave the step one. Present only when the workflow resolved a step; it is the last discriminator between two steps of one job that reference the same action. |
+
+Everything else in a finding's payload is **deliberately not part of identity**: `line` and `url` move whenever unrelated code above the finding is edited, `advisories` grows as CVEs are published, `latestVersion` moves on any upstream release, and status fields track current settings rather than identity. Any of those in the field set would make an unchanged finding look new.
+
+A platform ingesting Plumber reports should **store the identity fields the CLI selected instead of re-deriving them**, so the two sides can never disagree about which findings are the same finding. Go consumers can use the public [`finding/identity`](https://github.com/getplumber/plumber/tree/main/finding/identity) package (`identity.Of`, `identity.Fingerprint`, `identity.FromMap`) to work with the same recipe programmatically.


### PR DESCRIPTION
## What

Two related documentation updates for recent Plumber CLI changes.

### 1. Configuration: extendable config is now the default path

The CLI reference gets a new **Configuration** section presenting the three ways to run Plumber:

| Case | What you write |
|------|----------------|
| No configuration | Nothing: the built-in default policy runs (zero-config, no prompt, CI-safe) |
| Extended configuration (**recommended**) | A sparse overlay starting with `extends: plumber:default`, deep-merged onto the shipped baseline |
| Full configuration | A complete `.plumber.yaml` without `extends`; a control left out does not run |

Also documents the commands built for overlay mode: `config resolve`, `config slim`, `config generate --overlay`, `config view --explain`, and `includePlumberDefaults`.

The GitHub and GitLab pages now present the overlay as the recommended way to author a config, and no longer claim a `.plumber.yaml` is required (the Action and the CI component both run zero-config with the embedded default).

### 2. Output format: identity block from getplumber/plumber#404

- New **`identity` block** documented on each JSON issue entry: `version` (recipe version, currently 2), `fields` (the ordered key/value pairs the fingerprint is derived from), and `subjectFromMessage`, with guidance to store the selected fields instead of re-deriving them, and a pointer to the public `finding/identity` Go package.
- **`job` now strictly means a CI job**: updated the JSON `job` key and CSV `context` column descriptions; findings about a branch, include, or required template/component/action carry their subject in structured keys (`branchName`, `includePath`, `templatePath`, `componentPath`, `requiredAction`).

## Validation

- `npm run lint`: 0 errors (pre-existing warnings only, unrelated files)
- `npm run build`: succeeds; all new in-page anchors verified in the built HTML