### PR TITLE
fix(release): hold conventionalcommits preset at 10.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # 10.3+ requires conventional-changelog-writer@9, which
+      # @semantic-release/release-notes-generator (<= 14.x) does not ship;
+      # bumping it breaks the release job's generateNotes step. Drop this
+      # ignore once release-notes-generator depends on writer 9.
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        versions: [">10.2.1"]
 
   # Isolated deploy tooling (hash-locked Vercel CLI used by the deploy jobs)
   - package-ecosystem: "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@astrojs/ts-plugin": "^1.10.11",
         "@eslint/js": "10.0.1",
         "@playform/compress": "0.2.5",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "10.2.1",
         "eslint": "10.9.0",
         "eslint-plugin-astro": "3.1.0",
         "eslint-plugin-jsx-a11y": "6.10.2",
@@ -6868,13 +6868,13 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@astrojs/ts-plugin": "^1.10.11",
     "@eslint/js": "10.0.1",
     "@playform/compress": "0.2.5",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "10.2.1",
     "eslint": "10.9.0",
     "eslint-plugin-astro": "3.1.0",
     "eslint-plugin-jsx-a11y": "6.10.2",


### PR DESCRIPTION
Dependabot bumped conventional-changelog-conventionalcommits to 10.4.0, which refuses to render under conventional-changelog-writer 8: 10.3.0 started calling the writer 9 formatNoteIcon helper and 10.4.0 added an explicit guard that throws "Missing helper" at generateNotes time. Even the latest @semantic-release/release-notes-generator (14.1.1) still depends on writer ^8, so the release job on main fails.

Pin the preset to the last compatible version and tell Dependabot to skip newer ones until release-notes-generator ships with writer 9. Lockfile regenerated with npm 10 from the registry.